### PR TITLE
✨ Add Policy Server for Rate Limiting

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,141 +2,103 @@
 
 ## Project Overview
 
-This is a Postfix socketmap adapter for the [Userli](https://github.com/systemli/userli) email user management system. It provides TCP-based lookup services for Postfix to query virtual aliases, domains, mailboxes, and sender login maps from Userli's REST API.
+Postfix adapter for [Userli](https://github.com/systemli/userli) email management. Provides two TCP servers:
+
+- **Lookup Server** (`:10001`): Lookups for aliases, domains, mailboxes, senders
+- **Policy Server** (`:10003`): Rate limiting via Postfix SMTP Access Policy Delegation
 
 ## Architecture
 
-### Core Components
-
-- **Socketmap Server** (`server.go`): TCP server implementing Postfix's socketmap protocol on port 10001
-- **Userli Client** (`userli.go`): REST API client for querying Userli backend
-- **Metrics Server** (`prometheus.go`): Prometheus metrics endpoint on port 10002
-- **Adapter Logic** (`adapter.go`): Request routing and response formatting for four map types (alias, domain, mailbox, senders)
-
-### Request Flow
-
-1. Postfix sends socketmap query via TCP (format: `<netstring>MAP_NAME <SP> KEY`)
-2. Socketmap server parses request and routes to appropriate handler in adapter
-3. Adapter queries Userli REST API (`/api/postfix/{map_type}?query={key}`)
-4. Response converted back to socketmap netstring format
-5. Metrics updated for observability
-
-## Development Workflow
-
-### Local Setup
-
-```bash
-# Copy environment template
-cp .env.dist .env
-
-# Edit .env and set USERLI_TOKEN (required)
-# Token can be created in Userli: Settings -> Api Tokens
-
-# Start full stack (adapter + postfix + userli + mariadb + mailcatcher)
-docker-compose up
-
-# Adapter runs on :10001 (socketmap) and :10002 (metrics)
+```
+┌─────────┐     ┌──────────────────┐     ┌────────────┐
+│ Postfix │────▶│ tcpserver.go     │────▶│ Userli API │
+└─────────┘     │ (shared infra)   │     └────────────┘
+                ├──────────────────┤
+                │ lookup.go        │  ← ConnectionHandler interface
+                │ policy.go        │  ← ConnectionHandler interface
+                └──────────────────┘
 ```
 
-### Testing Postfix Integration
+### Key Pattern: ConnectionHandler Interface
+
+Both servers implement `ConnectionHandler` from `tcpserver.go`:
+
+```go
+type ConnectionHandler interface {
+    HandleConnection(ctx context.Context, conn net.Conn)
+}
+```
+
+`StartTCPServer()` provides shared infrastructure: connection pooling (semaphore), graceful shutdown, TCP keep-alive, metrics hooks.
+
+### File Structure
+
+| File            | Purpose                                                              |
+| --------------- | -------------------------------------------------------------------- |
+| `tcpserver.go`  | Shared TCP server with connection pooling, graceful shutdown         |
+| `lookup.go`     | Socketmap protocol + `LookupServer` (implements `ConnectionHandler`) |
+| `policy.go`     | Policy protocol + `PolicyServer` + rate limit logic                  |
+| `ratelimit.go`  | Sliding window rate limiter (in-memory, per-sender)                  |
+| `userli.go`     | HTTP client for Userli API with Bearer auth                          |
+| `prometheus.go` | Metrics server + all metric definitions                              |
+| `config.go`     | Environment variable configuration                                   |
+
+## Development
 
 ```bash
-# Test socketmap queries directly
-echo -e "10:alias test" | nc localhost 10001
+cp .env.dist .env  # Set USERLI_TOKEN
+docker-compose up  # Full stack: adapter + postfix + userli + mariadb + mailcatcher
 
-# Test via Postfix container
-docker-compose exec postfix postmap -q "user@example.org" socketmap:inet:adapter:10001:alias
+# Test lookup (via socketmap protocol)
 docker-compose exec postfix postmap -q "example.org" socketmap:inet:adapter:10001:domain
-docker-compose exec postfix postmap -q "user@example.org" socketmap:inet:adapter:10001:mailbox
-docker-compose exec postfix postmap -q "user@example.org" socketmap:inet:adapter:10001:senders
 
-# View caught test emails
-open http://localhost:1080  # Mailcatcher web UI
-```
-
-### Building & Testing
-
-```bash
-# Run tests with coverage
-go test ./...
-
-# Build binary
-go build -o userli-postfix-adapter
-
-# Build Docker image
-docker build -t systemli/userli-postfix-adapter .
+# Test policy (sends raw policy request)
+echo -e "request=smtpd_access_policy\nprotocol_state=END-OF-MESSAGE\nsender=test@example.org\n\n" | nc localhost 10003
 ```
 
 ## Code Conventions
 
-### Configuration Pattern
+### Context Propagation
 
-- Use environment variables exclusively (no config files)
-- **Required**: `USERLI_TOKEN` - application will fatal if missing
-- Defaults defined in `config.go:NewConfig()`:
-  - `USERLI_BASE_URL`: `http://localhost:8000`
-  - `SOCKETMAP_LISTEN_ADDR`: `:10001`
-  - `METRICS_LISTEN_ADDR`: `:10002`
-  - `LOG_LEVEL`: `info`
-  - `LOG_FORMAT`: `text` (or `json`)
+- Never store `context.Context` in structs - pass through function parameters
+- Use parent context for timeouts: `ctx, cancel := context.WithTimeout(parentCtx, 5*time.Second)`
 
 ### Error Handling
 
-- Use `logrus` for structured logging: `log.WithField("key", value).Error()`
-- Socketmap protocol requires specific error responses:
-  - `"TEMP "` - temporary failure (HTTP errors, network issues)
-  - `"PERM "` - permanent failure (404 not found)
-  - `"NOTFOUND "` - valid query but no result
-  - `"OK <value>"` - successful lookup
-- Fatal errors only for startup issues (missing token, port bind failures)
-- Network/API errors are logged but return TEMP to Postfix for retry
+- **Socketmap responses**: `OK <data>`, `NOTFOUND`, `TEMP <msg>`, `PERM <msg>`
+- **Policy responses**: `action=DUNNO\n\n` (allow) or `action=REJECT <msg>\n\n`
+- **Fail-open**: API errors return DUNNO/allow, never block mail on failures
 
-### Adapter Response Pattern
+### Metrics (prometheus.go)
 
-The adapter in `adapter.go` follows this flow:
+- No PII in labels - aggregate counters only, no email addresses
+- Metrics defined as package-level vars, registered in `StartMetricsServer()`
 
-```go
-// 1. Parse socketmap request (map name and key)
-// 2. Query Userli API: GET /api/postfix/{mapName}?query={key}
-// 3. Parse JSON response structure: {"exists": bool, "result": string}
-// 4. Return formatted response: "OK result" or "NOTFOUND "
+### Testing
+
+- Mocks generated via mockery (`.mockery.yml`) - regenerate with `mockery`
+- Use `context.Background()` in tests for handlers
+
+## Protocols
+
+### Socketmap (RFC-like netstring)
+
+```
+Request:  <len>:<mapname> <key>,    e.g., "18:domain example.org,"
+Response: <len>:<status> <data>,    e.g., "4:OK 1,"
 ```
 
-### Socketmap Protocol Implementation
+### Policy Delegation (Postfix SMTPD)
 
-- Request format: `<length>:<data>,` (netstring format)
-- Data format: `<mapName> <key>`
-- Responses must end with space and newline per Postfix spec
-- See `server.go:handleConnection()` for full protocol details
+```
+Request:  name=value\n pairs, empty line terminates
+Response: action=ACTION\n\n
+```
 
-### Testing with Mocks
-
-- Mock interfaces generated with `mockery` (see `mock_UserliService.go`)
-- Test files follow `*_test.go` naming convention
-- Use table-driven tests for multiple scenarios
-
-## Key Files
-
-- `main.go` - Entry point, initializes config and starts servers
-- `server.go` - TCP server and socketmap protocol implementation
-- `adapter.go` - Request routing and Userli API interaction
-- `userli.go` - HTTP client with Bearer token authentication
-- `config.go` - Environment-based configuration
-- `prometheus.go` - Metrics instrumentation
-- `docker-compose.yml` - Full test environment with Postfix, Userli, MariaDB, and Mailcatcher
-
-## External Dependencies
-
-- **Userli API**: REST endpoints at `/api/postfix/{alias,domain,mailbox,senders}?query={key}`
-  - Returns JSON: `{"exists": true/false, "result": "value"}`
-  - Requires Bearer token authentication
-- **Postfix Configuration**: Uses `socketmap:inet:adapter:10001:{mapName}` in virtual\_\*\_maps directives
-- **Prometheus**: Scrapes metrics from `:10002/metrics`
+Only process at `protocol_state=END-OF-MESSAGE` for accurate counting.
 
 ## Common Pitfalls
 
-- Forgetting to set `USERLI_TOKEN` in `.env` causes immediate startup failure
-- Map names in Postfix config must exactly match: `alias`, `domain`, `mailbox`, `senders`
-- Netstring format is strict: must include length prefix and comma suffix
-- Empty API responses (exists=false) should return "NOTFOUND ", not an error
-- All socketmap responses must end with space + newline for Postfix compatibility
+- `USERLI_TOKEN` is required - app exits immediately if missing
+- Rate limiter cleanup runs every 5 minutes in background goroutine
+- Map names must match exactly: `alias`, `domain`, `mailbox`, `senders`

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The adapter is configured via environment variables:
 - `USERLI_BASE_URL`: The base URL of the userli API.
 - `POSTFIX_RECIPIENT_DELIMITER`: The recipient delimiter used in Postfix (e.g., `+`). Default: empty.
 - `SOCKETMAP_LISTEN_ADDR`: The address to listen on for socketmap requests. Default: `:10001`.
+- `POLICY_LISTEN_ADDR`: The address to listen on for policy requests (rate limiting). Default: `:10003`.
 - `METRICS_LISTEN_ADDR`: The address to listen on for metrics. Default: `:10002`.
 
 In Postfix, you can configure the adapter using the socketmap protocol like this:
@@ -23,6 +24,28 @@ virtual_mailbox_domains = socketmap:inet:localhost:10001:domain
 virtual_mailbox_maps = socketmap:inet:localhost:10001:mailbox
 smtpd_sender_login_maps = socketmap:inet:localhost:10001:senders
 ```
+
+### Rate Limiting (Policy Server)
+
+The adapter also provides a Postfix SMTP Access Policy Delegation server for rate limiting outgoing mail.
+It queries the Userli API for per-user quotas and enforces sending limits.
+
+Configure in Postfix `main.cf`:
+
+```text
+smtpd_end_of_data_restrictions = check_policy_service inet:localhost:10003
+```
+
+The Userli API endpoint `/api/postfix/smtp_quota/{email}` returns:
+
+```json
+{
+    "per_hour": 100,
+    "per_day": 1000
+}
+```
+
+Where `0` means unlimited. If the API is unreachable, messages are allowed (fail-open).
 
 ## Docker
 
@@ -140,6 +163,15 @@ The adapter exposes Prometheus metrics on `/metrics` (port 10002) and provides h
 **Health:**
 
 - `userli_postfix_adapter_health_check_status` - Health check status (1=healthy, 0=unhealthy)
+
+**Policy/Rate Limiting Metrics:**
+
+- `userli_postfix_adapter_policy_active_connections` - Active policy connections gauge
+- `userli_postfix_adapter_policy_requests_total` - Total policy request counter
+- `userli_postfix_adapter_policy_request_duration_seconds` - Policy request duration histogram
+- `userli_postfix_adapter_quota_exceeded_total` - Total messages rejected due to quota
+- `userli_postfix_adapter_quota_checks_total` - Total quota checks performed
+- `userli_postfix_adapter_tracked_senders` - Number of senders tracked by rate limiter
 
 All metrics include relevant labels (handler, status, endpoint, etc.).
 

--- a/config.go
+++ b/config.go
@@ -19,6 +19,9 @@ type Config struct {
 	// SocketmapListenAddr is the address to listen for socketmap requests.
 	SocketmapListenAddr string
 
+	// PolicyListenAddr is the address to listen for policy requests.
+	PolicyListenAddr string
+
 	// MetricsListenAddr is the address to listen for metrics requests.
 	MetricsListenAddr string
 }
@@ -47,11 +50,17 @@ func NewConfig() (*Config, error) {
 		metricsListenAddr = ":10002"
 	}
 
+	policyListenAddr := os.Getenv("POLICY_LISTEN_ADDR")
+	if policyListenAddr == "" {
+		policyListenAddr = ":10003"
+	}
+
 	return &Config{
 		UserliBaseURL:             userliBaseURL,
 		UserliToken:               userliToken,
 		PostfixRecipientDelimiter: postfixRecipientDelimiter,
 		SocketmapListenAddr:       socketmapListenAddr,
+		PolicyListenAddr:          policyListenAddr,
 		MetricsListenAddr:         metricsListenAddr,
 	}, nil
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     ports:
       - "10001:10001"
       - "10002:10002"
+      - "10003:10003"
     env_file:
       - .env
     networks:
@@ -22,6 +23,7 @@ services:
       POSTFIX_virtual_mailbox_domains: "socketmap:inet:adapter:10001:domain"
       POSTFIX_virtual_mailbox_maps: "socketmap:inet:adapter:10001:mailbox"
       POSTFIX_smtpd_sender_login_maps: "socketmap:inet:adapter:10001:senders"
+      POSTFIX_smtpd_end_of_data_restrictions: "check_policy_service inet:adapter:10003"
     networks:
       - userli
 

--- a/mock_UserliService.go
+++ b/mock_UserliService.go
@@ -237,6 +237,74 @@ func (_c *MockUserliService_GetMailbox_Call) RunAndReturn(run func(ctx context.C
 	return _c
 }
 
+// GetQuota provides a mock function for the type MockUserliService
+func (_mock *MockUserliService) GetQuota(ctx context.Context, email string) (*Quota, error) {
+	ret := _mock.Called(ctx, email)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetQuota")
+	}
+
+	var r0 *Quota
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*Quota, error)); ok {
+		return returnFunc(ctx, email)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *Quota); ok {
+		r0 = returnFunc(ctx, email)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*Quota)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, email)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockUserliService_GetQuota_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetQuota'
+type MockUserliService_GetQuota_Call struct {
+	*mock.Call
+}
+
+// GetQuota is a helper method to define mock.On call
+//   - ctx context.Context
+//   - email string
+func (_e *MockUserliService_Expecter) GetQuota(ctx interface{}, email interface{}) *MockUserliService_GetQuota_Call {
+	return &MockUserliService_GetQuota_Call{Call: _e.mock.On("GetQuota", ctx, email)}
+}
+
+func (_c *MockUserliService_GetQuota_Call) Run(run func(ctx context.Context, email string)) *MockUserliService_GetQuota_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockUserliService_GetQuota_Call) Return(quota *Quota, err error) *MockUserliService_GetQuota_Call {
+	_c.Call.Return(quota, err)
+	return _c
+}
+
+func (_c *MockUserliService_GetQuota_Call) RunAndReturn(run func(ctx context.Context, email string) (*Quota, error)) *MockUserliService_GetQuota_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetSenders provides a mock function for the type MockUserliService
 func (_mock *MockUserliService) GetSenders(ctx context.Context, email string) ([]string, error) {
 	ret := _mock.Called(ctx, email)

--- a/policy.go
+++ b/policy.go
@@ -1,0 +1,252 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// PolicyServer implements a Postfix SMTP Access Policy Delegation server
+// for rate limiting outgoing mail based on sender quotas.
+type PolicyServer struct {
+	client      UserliService
+	rateLimiter *RateLimiter
+}
+
+// NewPolicyServer creates a new PolicyServer with the given UserliService
+func NewPolicyServer(client UserliService, rateLimiter *RateLimiter) *PolicyServer {
+	return &PolicyServer{
+		client:      client,
+		rateLimiter: rateLimiter,
+	}
+}
+
+// StartPolicyServer starts the policy server on the given address
+func StartPolicyServer(ctx context.Context, wg *sync.WaitGroup, addr string, server *PolicyServer) {
+	config := TCPServerConfig{
+		Name: "policy",
+		Addr: addr,
+		OnConnectionAcquired: func() {
+			policyActiveConnections.Inc()
+		},
+		OnConnectionReleased: func() {
+			policyActiveConnections.Dec()
+		},
+		OnConnectionPoolFull: func() {
+			policyConnectionPoolFullTotal.Inc()
+		},
+	}
+
+	StartTCPServer(ctx, wg, config, server)
+}
+
+// HandleConnection implements ConnectionHandler interface for PolicyServer
+func (p *PolicyServer) HandleConnection(ctx context.Context, conn net.Conn) {
+	reader := bufio.NewReader(conn)
+
+	for {
+		// Check if context is cancelled
+		if ctx.Err() != nil {
+			return
+		}
+
+		_ = conn.SetReadDeadline(time.Now().Add(ReadTimeout))
+
+		request, err := p.readRequest(reader)
+		if err != nil {
+			if !errors.Is(err, io.EOF) {
+				logger.Debug("Failed to read policy request", zap.Error(err))
+			}
+			return
+		}
+
+		response := p.handleRequest(ctx, request)
+
+		_ = conn.SetWriteDeadline(time.Now().Add(WriteTimeout))
+		if err := p.writeResponse(conn, response); err != nil {
+			logger.Error("Failed to write policy response", zap.Error(err))
+			return
+		}
+	}
+}
+
+// PolicyRequest represents a parsed Postfix policy request
+type PolicyRequest struct {
+	Request          string
+	ProtocolState    string
+	ProtocolName     string
+	Sender           string
+	Recipient        string
+	RecipientCount   string
+	ClientAddress    string
+	ClientName       string
+	SaslMethod       string
+	SaslUsername     string
+	Size             string
+	QueueID          string
+	Instance         string
+	EncryptionCipher string
+}
+
+// readRequest reads and parses a policy request from the connection
+func (p *PolicyServer) readRequest(reader *bufio.Reader) (*PolicyRequest, error) {
+	request := &PolicyRequest{}
+
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return nil, err
+		}
+
+		line = strings.TrimSpace(line)
+
+		// Empty line signals end of request
+		if line == "" {
+			break
+		}
+
+		// Parse name=value pairs
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+
+		name := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+
+		switch name {
+		case "request":
+			request.Request = value
+		case "protocol_state":
+			request.ProtocolState = value
+		case "protocol_name":
+			request.ProtocolName = value
+		case "sender":
+			request.Sender = value
+		case "recipient":
+			request.Recipient = value
+		case "recipient_count":
+			request.RecipientCount = value
+		case "client_address":
+			request.ClientAddress = value
+		case "client_name":
+			request.ClientName = value
+		case "sasl_method":
+			request.SaslMethod = value
+		case "sasl_username":
+			request.SaslUsername = value
+		case "size":
+			request.Size = value
+		case "queue_id":
+			request.QueueID = value
+		case "instance":
+			request.Instance = value
+		case "encryption_cipher":
+			request.EncryptionCipher = value
+		}
+	}
+
+	return request, nil
+}
+
+// handleRequest processes a policy request and returns an action
+func (p *PolicyServer) handleRequest(ctx context.Context, req *PolicyRequest) string {
+	startTime := time.Now()
+
+	logger.Debug("Processing policy request",
+		zap.String("sender", req.Sender),
+		zap.String("sasl_username", req.SaslUsername),
+		zap.String("protocol", req.ProtocolState))
+
+	// Only check at END-OF-MESSAGE stage for outgoing mail
+	// This ensures we only count messages that will actually be sent
+	if req.ProtocolState != "END-OF-MESSAGE" {
+		policyRequestsTotal.WithLabelValues("skip", "dunno").Inc()
+		policyRequestDuration.WithLabelValues("skip", "dunno").Observe(time.Since(startTime).Seconds())
+		return "DUNNO"
+	}
+
+	// Use SASL username as the sender identity for rate limiting
+	// This is more reliable than the envelope sender for authenticated users
+	sender := req.SaslUsername
+	if sender == "" {
+		sender = req.Sender
+	}
+
+	if sender == "" {
+		logger.Debug("No sender identity found, allowing message")
+		policyRequestsTotal.WithLabelValues("check", "dunno").Inc()
+		policyRequestDuration.WithLabelValues("check", "dunno").Observe(time.Since(startTime).Seconds())
+		return "DUNNO"
+	}
+
+	// Fetch quota from Userli API
+	quotaCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	quota, err := p.client.GetQuota(quotaCtx, sender)
+	if err != nil {
+		// API error - fail open (allow the message)
+		logger.Warn("Failed to fetch quota, allowing message",
+			zap.String("sender", sender), zap.Error(err))
+		policyRequestsTotal.WithLabelValues("check", "error").Inc()
+		policyRequestDuration.WithLabelValues("check", "error").Observe(time.Since(startTime).Seconds())
+		return "DUNNO"
+	}
+
+	// No limits configured (both 0 means unlimited)
+	if quota.PerHour == 0 && quota.PerDay == 0 {
+		logger.Debug("No quota limits configured", zap.String("sender", sender))
+		policyRequestsTotal.WithLabelValues("check", "dunno").Inc()
+		policyRequestDuration.WithLabelValues("check", "dunno").Observe(time.Since(startTime).Seconds())
+		return "DUNNO"
+	}
+
+	// Check rate limit
+	allowed, hourCount, dayCount := p.rateLimiter.CheckAndIncrement(sender, quota)
+
+	// Update metrics
+	quotaChecksTotal.WithLabelValues("checked").Inc()
+
+	if !allowed {
+		logger.Info("Rate limit exceeded",
+			zap.String("sender", sender),
+			zap.Int("hour_count", hourCount),
+			zap.Int("day_count", dayCount),
+			zap.Int("hour_limit", quota.PerHour),
+			zap.Int("day_limit", quota.PerDay))
+
+		policyRequestsTotal.WithLabelValues("check", "reject").Inc()
+		policyRequestDuration.WithLabelValues("check", "reject").Observe(time.Since(startTime).Seconds())
+		quotaExceededTotal.Inc()
+
+		return "REJECT Rate limit exceeded, please try again later"
+	}
+
+	logger.Debug("Message allowed",
+		zap.String("sender", sender),
+		zap.Int("hour_count", hourCount),
+		zap.Int("day_count", dayCount),
+		zap.Int("hour_limit", quota.PerHour),
+		zap.Int("day_limit", quota.PerDay))
+
+	policyRequestsTotal.WithLabelValues("check", "dunno").Inc()
+	policyRequestDuration.WithLabelValues("check", "dunno").Observe(time.Since(startTime).Seconds())
+
+	return "DUNNO"
+}
+
+// writeResponse writes the policy response to the connection
+func (p *PolicyServer) writeResponse(conn net.Conn, action string) error {
+	response := fmt.Sprintf("action=%s\n\n", action)
+	_, err := conn.Write([]byte(response))
+	return err
+}

--- a/policy_test.go
+++ b/policy_test.go
@@ -1,0 +1,557 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// MockUserliService is a mock implementation for testing
+type MockUserliServiceForPolicy struct {
+	quota    *Quota
+	quotaErr error
+}
+
+func (m *MockUserliServiceForPolicy) GetAliases(_ context.Context, _ string) ([]string, error) {
+	return nil, nil
+}
+
+func (m *MockUserliServiceForPolicy) GetDomain(_ context.Context, _ string) (bool, error) {
+	return false, nil
+}
+
+func (m *MockUserliServiceForPolicy) GetMailbox(_ context.Context, _ string) (bool, error) {
+	return false, nil
+}
+
+func (m *MockUserliServiceForPolicy) GetSenders(_ context.Context, _ string) ([]string, error) {
+	return nil, nil
+}
+
+func (m *MockUserliServiceForPolicy) GetQuota(_ context.Context, _ string) (*Quota, error) {
+	if m.quotaErr != nil {
+		return nil, m.quotaErr
+	}
+	return m.quota, nil
+}
+
+func TestPolicyServer_ReadRequest(t *testing.T) {
+	input := `request=smtpd_access_policy
+protocol_state=END-OF-MESSAGE
+protocol_name=SMTP
+sender=user@example.org
+recipient=recipient@example.com
+sasl_username=user@example.org
+client_address=192.168.1.1
+
+`
+	reader := bufio.NewReader(strings.NewReader(input))
+	server := &PolicyServer{}
+
+	req, err := server.readRequest(reader)
+	if err != nil {
+		t.Fatalf("Failed to read request: %v", err)
+	}
+
+	if req.Request != "smtpd_access_policy" {
+		t.Errorf("Expected request=smtpd_access_policy, got %s", req.Request)
+	}
+	if req.ProtocolState != "END-OF-MESSAGE" {
+		t.Errorf("Expected protocol_state=END-OF-MESSAGE, got %s", req.ProtocolState)
+	}
+	if req.Sender != "user@example.org" {
+		t.Errorf("Expected sender=user@example.org, got %s", req.Sender)
+	}
+	if req.SaslUsername != "user@example.org" {
+		t.Errorf("Expected sasl_username=user@example.org, got %s", req.SaslUsername)
+	}
+}
+
+func TestPolicyServer_HandleRequest_SkipNonEndOfMessage(t *testing.T) {
+	mockClient := &MockUserliServiceForPolicy{
+		quota: &Quota{PerHour: 10, PerDay: 100},
+	}
+	rateLimiter := &RateLimiter{
+		counters: make(map[string]*senderCounter),
+	}
+	server := NewPolicyServer(mockClient, rateLimiter)
+
+	req := &PolicyRequest{
+		ProtocolState: "RCPT",
+		Sender:        "user@example.org",
+		SaslUsername:  "user@example.org",
+	}
+
+	response := server.handleRequest(context.Background(), req)
+
+	if response != "DUNNO" {
+		t.Errorf("Expected DUNNO for non-END-OF-MESSAGE state, got %s", response)
+	}
+}
+
+func TestPolicyServer_HandleRequest_NoSender(t *testing.T) {
+	mockClient := &MockUserliServiceForPolicy{
+		quota: &Quota{PerHour: 10, PerDay: 100},
+	}
+	rateLimiter := &RateLimiter{
+		counters: make(map[string]*senderCounter),
+	}
+	server := NewPolicyServer(mockClient, rateLimiter)
+
+	req := &PolicyRequest{
+		ProtocolState: "END-OF-MESSAGE",
+		Sender:        "",
+		SaslUsername:  "",
+	}
+
+	response := server.handleRequest(context.Background(), req)
+
+	if response != "DUNNO" {
+		t.Errorf("Expected DUNNO for empty sender, got %s", response)
+	}
+}
+
+func TestPolicyServer_HandleRequest_APIError(t *testing.T) {
+	mockClient := &MockUserliServiceForPolicy{
+		quotaErr: fmt.Errorf("API error"),
+	}
+	rateLimiter := &RateLimiter{
+		counters: make(map[string]*senderCounter),
+	}
+	server := NewPolicyServer(mockClient, rateLimiter)
+
+	req := &PolicyRequest{
+		ProtocolState: "END-OF-MESSAGE",
+		Sender:        "user@example.org",
+		SaslUsername:  "user@example.org",
+	}
+
+	response := server.handleRequest(context.Background(), req)
+
+	// Should fail open (allow message) when API is unavailable
+	if response != "DUNNO" {
+		t.Errorf("Expected DUNNO on API error (fail open), got %s", response)
+	}
+}
+
+func TestPolicyServer_HandleRequest_NoLimits(t *testing.T) {
+	mockClient := &MockUserliServiceForPolicy{
+		quota: &Quota{PerHour: 0, PerDay: 0},
+	}
+	rateLimiter := &RateLimiter{
+		counters: make(map[string]*senderCounter),
+	}
+	server := NewPolicyServer(mockClient, rateLimiter)
+
+	req := &PolicyRequest{
+		ProtocolState: "END-OF-MESSAGE",
+		Sender:        "user@example.org",
+		SaslUsername:  "user@example.org",
+	}
+
+	response := server.handleRequest(context.Background(), req)
+
+	if response != "DUNNO" {
+		t.Errorf("Expected DUNNO for unlimited quota, got %s", response)
+	}
+}
+
+func TestPolicyServer_HandleRequest_AllowedMessage(t *testing.T) {
+	mockClient := &MockUserliServiceForPolicy{
+		quota: &Quota{PerHour: 10, PerDay: 100},
+	}
+	rateLimiter := &RateLimiter{
+		counters: make(map[string]*senderCounter),
+	}
+	server := NewPolicyServer(mockClient, rateLimiter)
+
+	req := &PolicyRequest{
+		ProtocolState: "END-OF-MESSAGE",
+		Sender:        "user@example.org",
+		SaslUsername:  "user@example.org",
+	}
+
+	response := server.handleRequest(context.Background(), req)
+
+	if response != "DUNNO" {
+		t.Errorf("Expected DUNNO for allowed message, got %s", response)
+	}
+}
+
+func TestPolicyServer_HandleRequest_RateLimited(t *testing.T) {
+	mockClient := &MockUserliServiceForPolicy{
+		quota: &Quota{PerHour: 2, PerDay: 100},
+	}
+	rateLimiter := &RateLimiter{
+		counters: make(map[string]*senderCounter),
+	}
+	server := NewPolicyServer(mockClient, rateLimiter)
+
+	req := &PolicyRequest{
+		ProtocolState: "END-OF-MESSAGE",
+		Sender:        "user@example.org",
+		SaslUsername:  "user@example.org",
+	}
+
+	// First 2 messages should pass
+	for i := 0; i < 2; i++ {
+		response := server.handleRequest(context.Background(), req)
+		if response != "DUNNO" {
+			t.Errorf("Message %d should be allowed, got %s", i+1, response)
+		}
+	}
+
+	// 3rd message should be rejected
+	response := server.handleRequest(context.Background(), req)
+	if !strings.HasPrefix(response, "REJECT") {
+		t.Errorf("3rd message should be rejected, got %s", response)
+	}
+	if !strings.Contains(response, "Rate limit exceeded") {
+		t.Errorf("Expected rate limit message, got %s", response)
+	}
+}
+
+func TestPolicyServer_HandleRequest_UsesSaslUsername(t *testing.T) {
+	mockClient := &MockUserliServiceForPolicy{
+		quota: &Quota{PerHour: 1, PerDay: 100},
+	}
+	rateLimiter := &RateLimiter{
+		counters: make(map[string]*senderCounter),
+	}
+	server := NewPolicyServer(mockClient, rateLimiter)
+
+	// First request uses sasl_username
+	req1 := &PolicyRequest{
+		ProtocolState: "END-OF-MESSAGE",
+		Sender:        "different@example.org",
+		SaslUsername:  "user@example.org",
+	}
+	server.handleRequest(context.Background(), req1)
+
+	// Second request with same sasl_username should be limited
+	req2 := &PolicyRequest{
+		ProtocolState: "END-OF-MESSAGE",
+		Sender:        "another@example.org",
+		SaslUsername:  "user@example.org",
+	}
+	response := server.handleRequest(context.Background(), req2)
+
+	if !strings.HasPrefix(response, "REJECT") {
+		t.Errorf("Should use sasl_username for rate limiting, got %s", response)
+	}
+}
+
+func TestPolicyServer_Integration(t *testing.T) {
+	mockClient := &MockUserliServiceForPolicy{
+		quota: &Quota{PerHour: 100, PerDay: 1000},
+	}
+	rateLimiter := &RateLimiter{
+		counters: make(map[string]*senderCounter),
+	}
+	server := NewPolicyServer(mockClient, rateLimiter)
+
+	// Start server on random port
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Failed to create listener: %v", err)
+	}
+	defer listener.Close()
+
+	addr := listener.Addr().String()
+
+	// Handle one connection in background
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		reader := bufio.NewReader(conn)
+		req, _ := server.readRequest(reader)
+		response := server.handleRequest(context.Background(), req)
+		_ = server.writeResponse(conn, response)
+		conn.Close()
+	}()
+
+	// Connect as client
+	conn, err := net.DialTimeout("tcp", addr, time.Second)
+	if err != nil {
+		t.Fatalf("Failed to connect: %v", err)
+	}
+	defer conn.Close()
+
+	// Send policy request
+	request := `request=smtpd_access_policy
+protocol_state=END-OF-MESSAGE
+sender=test@example.org
+sasl_username=test@example.org
+
+`
+	_, err = conn.Write([]byte(request))
+	if err != nil {
+		t.Fatalf("Failed to write request: %v", err)
+	}
+
+	// Read response
+	reader := bufio.NewReader(conn)
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		t.Fatalf("Failed to read response: %v", err)
+	}
+
+	if !strings.HasPrefix(response, "action=DUNNO") {
+		t.Errorf("Expected action=DUNNO, got %s", response)
+	}
+}
+
+func TestPolicyServer_HandleConnection(t *testing.T) {
+	mockClient := &MockUserliServiceForPolicy{
+		quota: &Quota{PerHour: 100, PerDay: 1000},
+	}
+	rateLimiter := &RateLimiter{
+		counters: make(map[string]*senderCounter),
+	}
+	server := NewPolicyServer(mockClient, rateLimiter)
+
+	serverConn, clientConn := net.Pipe()
+	defer serverConn.Close()
+	defer clientConn.Close()
+
+	// Start HandleConnection in background
+	done := make(chan struct{})
+	go func() {
+		server.HandleConnection(context.Background(), serverConn)
+		close(done)
+	}()
+
+	// Send policy request
+	request := "request=smtpd_access_policy\nprotocol_state=END-OF-MESSAGE\nsender=test@example.org\n\n"
+	_, err := clientConn.Write([]byte(request))
+	if err != nil {
+		t.Fatalf("Failed to write request: %v", err)
+	}
+
+	// Read response
+	reader := bufio.NewReader(clientConn)
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		t.Fatalf("Failed to read response: %v", err)
+	}
+
+	if !strings.HasPrefix(response, "action=DUNNO") {
+		t.Errorf("Expected action=DUNNO, got %s", response)
+	}
+
+	// Close client connection to trigger EOF and exit handler
+	clientConn.Close()
+
+	// Wait for handler to exit
+	select {
+	case <-done:
+		// Success
+	case <-time.After(2 * time.Second):
+		t.Fatal("HandleConnection did not exit after client disconnect")
+	}
+}
+
+func TestPolicyServer_HandleConnection_MultipleRequests(t *testing.T) {
+	mockClient := &MockUserliServiceForPolicy{
+		quota: &Quota{PerHour: 100, PerDay: 1000},
+	}
+	rateLimiter := &RateLimiter{
+		counters: make(map[string]*senderCounter),
+	}
+	server := NewPolicyServer(mockClient, rateLimiter)
+
+	serverConn, clientConn := net.Pipe()
+	defer serverConn.Close()
+	defer clientConn.Close()
+
+	go server.HandleConnection(context.Background(), serverConn)
+
+	reader := bufio.NewReader(clientConn)
+
+	// Send first request
+	request1 := "request=smtpd_access_policy\nprotocol_state=END-OF-MESSAGE\nsender=user1@example.org\n\n"
+	_, err := clientConn.Write([]byte(request1))
+	if err != nil {
+		t.Fatalf("Failed to write first request: %v", err)
+	}
+
+	// Read first response (two lines: action line + empty line)
+	response1, _ := reader.ReadString('\n')
+	reader.ReadString('\n') // consume empty line
+	if !strings.HasPrefix(response1, "action=DUNNO") {
+		t.Errorf("Expected first response action=DUNNO, got %s", response1)
+	}
+
+	// Send second request
+	request2 := "request=smtpd_access_policy\nprotocol_state=RCPT\nsender=user2@example.org\n\n"
+	_, err = clientConn.Write([]byte(request2))
+	if err != nil {
+		t.Fatalf("Failed to write second request: %v", err)
+	}
+
+	// Read second response
+	response2, _ := reader.ReadString('\n')
+	if !strings.HasPrefix(response2, "action=DUNNO") {
+		t.Errorf("Expected second response action=DUNNO, got %s", response2)
+	}
+}
+
+func TestPolicyServer_StartPolicyServer(t *testing.T) {
+	mockClient := &MockUserliServiceForPolicy{
+		quota: &Quota{PerHour: 100, PerDay: 1000},
+	}
+	rateLimiter := &RateLimiter{
+		counters: make(map[string]*senderCounter),
+	}
+	server := NewPolicyServer(mockClient, rateLimiter)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+
+	// Start server on random port
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Failed to create listener: %v", err)
+	}
+	addr := listener.Addr().String()
+	listener.Close()
+
+	wg.Add(1)
+	go StartPolicyServer(ctx, &wg, addr, server)
+
+	// Give server time to start
+	time.Sleep(100 * time.Millisecond)
+
+	// Connect and send request
+	conn, err := net.DialTimeout("tcp", addr, time.Second)
+	if err != nil {
+		t.Fatalf("Failed to connect: %v", err)
+	}
+
+	request := "request=smtpd_access_policy\nprotocol_state=END-OF-MESSAGE\nsender=test@example.org\n\n"
+	_, _ = conn.Write([]byte(request))
+
+	reader := bufio.NewReader(conn)
+	response, _ := reader.ReadString('\n')
+	conn.Close()
+
+	if !strings.HasPrefix(response, "action=DUNNO") {
+		t.Errorf("Expected action=DUNNO, got %s", response)
+	}
+
+	// Shutdown
+	cancel()
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success
+	case <-time.After(5 * time.Second):
+		t.Fatal("Server did not shutdown within timeout")
+	}
+}
+
+func TestPolicyServer_ReadRequest_AllFields(t *testing.T) {
+	input := `request=smtpd_access_policy
+protocol_state=END-OF-MESSAGE
+protocol_name=ESMTP
+sender=user@example.org
+recipient=recipient@example.com
+recipient_count=5
+client_address=192.168.1.1
+client_name=mail.example.org
+sasl_method=PLAIN
+sasl_username=user@example.org
+size=12345
+queue_id=ABC123
+instance=def456
+encryption_cipher=TLS_AES_256_GCM_SHA384
+
+`
+	reader := bufio.NewReader(strings.NewReader(input))
+	server := &PolicyServer{}
+
+	req, err := server.readRequest(reader)
+	if err != nil {
+		t.Fatalf("Failed to read request: %v", err)
+	}
+
+	// Verify all fields
+	if req.Request != "smtpd_access_policy" {
+		t.Errorf("Request: got %s, want smtpd_access_policy", req.Request)
+	}
+	if req.ProtocolState != "END-OF-MESSAGE" {
+		t.Errorf("ProtocolState: got %s, want END-OF-MESSAGE", req.ProtocolState)
+	}
+	if req.ProtocolName != "ESMTP" {
+		t.Errorf("ProtocolName: got %s, want ESMTP", req.ProtocolName)
+	}
+	if req.Sender != "user@example.org" {
+		t.Errorf("Sender: got %s, want user@example.org", req.Sender)
+	}
+	if req.Recipient != "recipient@example.com" {
+		t.Errorf("Recipient: got %s, want recipient@example.com", req.Recipient)
+	}
+	if req.RecipientCount != "5" {
+		t.Errorf("RecipientCount: got %s, want 5", req.RecipientCount)
+	}
+	if req.ClientAddress != "192.168.1.1" {
+		t.Errorf("ClientAddress: got %s, want 192.168.1.1", req.ClientAddress)
+	}
+	if req.ClientName != "mail.example.org" {
+		t.Errorf("ClientName: got %s, want mail.example.org", req.ClientName)
+	}
+	if req.SaslMethod != "PLAIN" {
+		t.Errorf("SaslMethod: got %s, want PLAIN", req.SaslMethod)
+	}
+	if req.SaslUsername != "user@example.org" {
+		t.Errorf("SaslUsername: got %s, want user@example.org", req.SaslUsername)
+	}
+	if req.Size != "12345" {
+		t.Errorf("Size: got %s, want 12345", req.Size)
+	}
+	if req.QueueID != "ABC123" {
+		t.Errorf("QueueID: got %s, want ABC123", req.QueueID)
+	}
+	if req.Instance != "def456" {
+		t.Errorf("Instance: got %s, want def456", req.Instance)
+	}
+	if req.EncryptionCipher != "TLS_AES_256_GCM_SHA384" {
+		t.Errorf("EncryptionCipher: got %s, want TLS_AES_256_GCM_SHA384", req.EncryptionCipher)
+	}
+}
+
+func TestPolicyServer_ReadRequest_InvalidLine(t *testing.T) {
+	// Line without equals sign should be skipped
+	input := `request=smtpd_access_policy
+invalidline
+sender=user@example.org
+
+`
+	reader := bufio.NewReader(strings.NewReader(input))
+	server := &PolicyServer{}
+
+	req, err := server.readRequest(reader)
+	if err != nil {
+		t.Fatalf("Failed to read request: %v", err)
+	}
+
+	if req.Request != "smtpd_access_policy" {
+		t.Errorf("Request: got %s, want smtpd_access_policy", req.Request)
+	}
+	if req.Sender != "user@example.org" {
+		t.Errorf("Sender: got %s, want user@example.org", req.Sender)
+	}
+}

--- a/prometheus.go
+++ b/prometheus.go
@@ -57,11 +57,54 @@ var (
 		Name: "userli_postfix_adapter_health_check_status",
 		Help: "Health check status (1 = healthy, 0 = unhealthy)",
 	})
+
+	// Policy server metrics
+	policyActiveConnections = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "userli_postfix_adapter_policy_active_connections",
+		Help: "Number of currently active policy connections",
+	})
+
+	policyRequestsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "userli_postfix_adapter_policy_requests_total",
+		Help: "Total number of policy requests",
+	}, []string{"stage", "action"})
+
+	policyRequestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "userli_postfix_adapter_policy_request_duration_seconds",
+		Help:    "Duration of policy requests",
+		Buckets: prometheus.ExponentialBuckets(0.001, 2, 10),
+	}, []string{"stage", "action"})
+
+	quotaExceededTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "userli_postfix_adapter_quota_exceeded_total",
+		Help: "Total number of messages rejected due to quota",
+	})
+
+	quotaChecksTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "userli_postfix_adapter_quota_checks_total",
+		Help: "Total number of quota checks performed",
+	}, []string{"result"})
+
+	policyConnectionPoolFullTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "userli_postfix_adapter_policy_connection_pool_full_total",
+		Help: "Total number of policy connections rejected because the connection pool is full",
+	})
 )
 
 // StartMetricsServer starts a new HTTP server for prometheus metrics and health checks.
-func StartMetricsServer(ctx context.Context, listenAddr string, userliClient UserliService) {
+func StartMetricsServer(ctx context.Context, listenAddr string, userliClient UserliService, rateLimiter *RateLimiter) {
 	registry := prometheus.NewRegistry()
+
+	// Create tracked senders gauge with closure capturing the rate limiter
+	trackedSenders := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name: "userli_postfix_adapter_tracked_senders",
+		Help: "Number of senders currently tracked by rate limiter",
+	}, func() float64 {
+		if rateLimiter != nil {
+			return float64(rateLimiter.SenderCount())
+		}
+		return 0
+	})
 
 	registry.MustRegister(
 		collectors.NewGoCollector(),
@@ -73,6 +116,13 @@ func StartMetricsServer(ctx context.Context, listenAddr string, userliClient Use
 		httpClientDuration,
 		httpClientRequestsTotal,
 		healthCheckStatus,
+		policyActiveConnections,
+		policyRequestsTotal,
+		policyRequestDuration,
+		quotaExceededTotal,
+		quotaChecksTotal,
+		policyConnectionPoolFullTotal,
+		trackedSenders,
 	)
 
 	mux := http.NewServeMux()

--- a/prometheus_test.go
+++ b/prometheus_test.go
@@ -25,7 +25,7 @@ func (s *PrometheusTestSuite) TestHealthHandler() {
 
 		s.Equal(http.StatusOK, w.Code)
 		s.Equal("application/json", w.Header().Get("Content-Type"))
-		s.Equal("{\"status\":\"ok\"}\n", w.Body.String())
+		s.Equal(`{"status":"ok"}`+"\n", w.Body.String())
 	})
 }
 
@@ -42,7 +42,7 @@ func (s *PrometheusTestSuite) TestReadyHandler() {
 
 		s.Equal(http.StatusOK, w.Code)
 		s.Equal("application/json", w.Header().Get("Content-Type"))
-		s.Equal("{\"status\":\"ready\"}\n", w.Body.String())
+		s.Equal(`{"status":"ready"}`+"\n", w.Body.String())
 
 		mockClient.AssertExpectations(s.T())
 	})
@@ -59,7 +59,7 @@ func (s *PrometheusTestSuite) TestReadyHandler() {
 
 		s.Equal(http.StatusServiceUnavailable, w.Code)
 		s.Equal("application/json", w.Header().Get("Content-Type"))
-		s.Equal("{\"error\":\"connection refused\",\"status\":\"unavailable\"}\n", w.Body.String())
+		s.Equal(`{"error":"connection refused","status":"unavailable"}`+"\n", w.Body.String())
 
 		mockClient.AssertExpectations(s.T())
 	})
@@ -80,7 +80,7 @@ func (s *PrometheusTestSuite) TestReadyHandler() {
 
 		s.Equal(http.StatusServiceUnavailable, w.Code)
 		s.Equal("application/json", w.Header().Get("Content-Type"))
-		s.Equal("{\"error\":\"timeout\",\"status\":\"unavailable\"}\n", w.Body.String())
+		s.Equal(`{"error":"timeout","status":"unavailable"}`+"\n", w.Body.String())
 	})
 }
 
@@ -124,11 +124,14 @@ func (s *PrometheusTestSuite) TestStartMetricsServer() {
 		// Use a random available port
 		listenAddr := "127.0.0.1:0"
 
+		// Create a rate limiter for the test
+		rateLimiter := NewRateLimiter(context.Background())
+
 		// Start server in goroutine
 		serverStarted := make(chan struct{})
 		go func() {
 			close(serverStarted)
-			StartMetricsServer(ctx, listenAddr, mockClient)
+			StartMetricsServer(ctx, listenAddr, mockClient, rateLimiter)
 		}()
 
 		// Wait for server to start

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// RateLimiter tracks sending rates per sender using a sliding window approach.
+// It stores timestamps of sent messages and counts them within time windows.
+type RateLimiter struct {
+	mu       sync.RWMutex
+	counters map[string]*senderCounter
+}
+
+// senderCounter tracks message timestamps for a single sender
+type senderCounter struct {
+	timestamps []time.Time
+	mu         sync.Mutex
+}
+
+// NewRateLimiter creates a new RateLimiter instance
+func NewRateLimiter(ctx context.Context) *RateLimiter {
+	rl := &RateLimiter{
+		counters: make(map[string]*senderCounter),
+	}
+
+	// Start background cleanup goroutine
+	go rl.cleanupLoop(ctx)
+
+	return rl
+}
+
+// CheckAndIncrement checks if the sender is within quota limits and increments the counter if allowed.
+// Returns true if the message should be allowed, false if rate limited.
+// If quota limits are 0, they are treated as unlimited.
+func (rl *RateLimiter) CheckAndIncrement(sender string, quota *Quota) (allowed bool, hourCount, dayCount int) {
+	if quota == nil {
+		return true, 0, 0
+	}
+
+	// Get or create counter for this sender
+	rl.mu.Lock()
+	counter, exists := rl.counters[sender]
+	if !exists {
+		counter = &senderCounter{
+			timestamps: make([]time.Time, 0),
+		}
+		rl.counters[sender] = counter
+	}
+	rl.mu.Unlock()
+
+	counter.mu.Lock()
+	defer counter.mu.Unlock()
+
+	now := time.Now()
+	hourAgo := now.Add(-time.Hour)
+	dayAgo := now.Add(-24 * time.Hour)
+
+	// Clean old timestamps and count current usage
+	validTimestamps := make([]time.Time, 0, len(counter.timestamps))
+	hourCount = 0
+	dayCount = 0
+
+	for _, ts := range counter.timestamps {
+		if ts.After(dayAgo) {
+			validTimestamps = append(validTimestamps, ts)
+			dayCount++
+			if ts.After(hourAgo) {
+				hourCount++
+			}
+		}
+	}
+
+	counter.timestamps = validTimestamps
+
+	// Check limits (0 means unlimited)
+	if quota.PerHour > 0 && hourCount >= quota.PerHour {
+		return false, hourCount, dayCount
+	}
+	if quota.PerDay > 0 && dayCount >= quota.PerDay {
+		return false, hourCount, dayCount
+	}
+
+	// Add new timestamp
+	counter.timestamps = append(counter.timestamps, now)
+	hourCount++
+	dayCount++
+
+	return true, hourCount, dayCount
+}
+
+// GetCounts returns the current hour and day counts for a sender without incrementing
+func (rl *RateLimiter) GetCounts(sender string) (hourCount, dayCount int) {
+	rl.mu.RLock()
+	counter, exists := rl.counters[sender]
+	rl.mu.RUnlock()
+
+	if !exists {
+		return 0, 0
+	}
+
+	counter.mu.Lock()
+	defer counter.mu.Unlock()
+
+	now := time.Now()
+	hourAgo := now.Add(-time.Hour)
+	dayAgo := now.Add(-24 * time.Hour)
+
+	for _, ts := range counter.timestamps {
+		if ts.After(dayAgo) {
+			dayCount++
+			if ts.After(hourAgo) {
+				hourCount++
+			}
+		}
+	}
+
+	return hourCount, dayCount
+}
+
+// cleanupLoop periodically removes old entries to prevent memory leaks
+func (rl *RateLimiter) cleanupLoop(ctx context.Context) {
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			rl.cleanup()
+		}
+	}
+}
+
+// cleanup removes entries older than 24 hours
+func (rl *RateLimiter) cleanup() {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	dayAgo := time.Now().Add(-24 * time.Hour)
+
+	// Collect senders to delete after iteration
+	var toDelete []string
+
+	for sender, counter := range rl.counters {
+		counter.mu.Lock()
+
+		// Remove old timestamps
+		validTimestamps := make([]time.Time, 0, len(counter.timestamps))
+		for _, ts := range counter.timestamps {
+			if ts.After(dayAgo) {
+				validTimestamps = append(validTimestamps, ts)
+			}
+		}
+		counter.timestamps = validTimestamps
+
+		// Mark sender for deletion if no recent activity
+		if len(counter.timestamps) == 0 {
+			toDelete = append(toDelete, sender)
+		}
+
+		counter.mu.Unlock()
+	}
+
+	// Delete after iteration to avoid modifying map during range
+	for _, sender := range toDelete {
+		delete(rl.counters, sender)
+	}
+}
+
+// SenderCount returns the number of tracked senders (for metrics)
+func (rl *RateLimiter) SenderCount() int {
+	rl.mu.RLock()
+	defer rl.mu.RUnlock()
+	return len(rl.counters)
+}

--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -1,0 +1,211 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRateLimiter_CheckAndIncrement_NoLimits(t *testing.T) {
+	rl := &RateLimiter{
+		counters: make(map[string]*senderCounter),
+	}
+
+	quota := &Quota{PerHour: 0, PerDay: 0}
+	allowed, hourCount, dayCount := rl.CheckAndIncrement("test@example.org", quota)
+
+	if !allowed {
+		t.Error("Expected message to be allowed when no limits are set")
+	}
+	if hourCount != 1 || dayCount != 1 {
+		t.Errorf("Expected counts to be 1, got hour=%d, day=%d", hourCount, dayCount)
+	}
+}
+
+func TestRateLimiter_CheckAndIncrement_NilQuota(t *testing.T) {
+	rl := &RateLimiter{
+		counters: make(map[string]*senderCounter),
+	}
+
+	allowed, hourCount, dayCount := rl.CheckAndIncrement("test@example.org", nil)
+
+	if !allowed {
+		t.Error("Expected message to be allowed when quota is nil")
+	}
+	if hourCount != 0 || dayCount != 0 {
+		t.Errorf("Expected counts to be 0, got hour=%d, day=%d", hourCount, dayCount)
+	}
+}
+
+func TestRateLimiter_CheckAndIncrement_HourlyLimit(t *testing.T) {
+	rl := &RateLimiter{
+		counters: make(map[string]*senderCounter),
+	}
+
+	quota := &Quota{PerHour: 3, PerDay: 100}
+	sender := "test@example.org"
+
+	// First 3 messages should be allowed
+	for i := 0; i < 3; i++ {
+		allowed, _, _ := rl.CheckAndIncrement(sender, quota)
+		if !allowed {
+			t.Errorf("Message %d should be allowed", i+1)
+		}
+	}
+
+	// 4th message should be rejected
+	allowed, hourCount, _ := rl.CheckAndIncrement(sender, quota)
+	if allowed {
+		t.Error("4th message should be rejected due to hourly limit")
+	}
+	if hourCount != 3 {
+		t.Errorf("Expected hourCount to be 3, got %d", hourCount)
+	}
+}
+
+func TestRateLimiter_CheckAndIncrement_DailyLimit(t *testing.T) {
+	rl := &RateLimiter{
+		counters: make(map[string]*senderCounter),
+	}
+
+	quota := &Quota{PerHour: 100, PerDay: 3}
+	sender := "test@example.org"
+
+	// First 3 messages should be allowed
+	for i := 0; i < 3; i++ {
+		allowed, _, _ := rl.CheckAndIncrement(sender, quota)
+		if !allowed {
+			t.Errorf("Message %d should be allowed", i+1)
+		}
+	}
+
+	// 4th message should be rejected
+	allowed, _, dayCount := rl.CheckAndIncrement(sender, quota)
+	if allowed {
+		t.Error("4th message should be rejected due to daily limit")
+	}
+	if dayCount != 3 {
+		t.Errorf("Expected dayCount to be 3, got %d", dayCount)
+	}
+}
+
+func TestRateLimiter_CheckAndIncrement_MultipleSenders(t *testing.T) {
+	rl := &RateLimiter{
+		counters: make(map[string]*senderCounter),
+	}
+
+	quota := &Quota{PerHour: 2, PerDay: 10}
+	sender1 := "user1@example.org"
+	sender2 := "user2@example.org"
+
+	// Each sender should have their own quota
+	for i := 0; i < 2; i++ {
+		allowed1, _, _ := rl.CheckAndIncrement(sender1, quota)
+		allowed2, _, _ := rl.CheckAndIncrement(sender2, quota)
+		if !allowed1 || !allowed2 {
+			t.Errorf("Message %d should be allowed for both senders", i+1)
+		}
+	}
+
+	// Both should be at limit now
+	allowed1, _, _ := rl.CheckAndIncrement(sender1, quota)
+	allowed2, _, _ := rl.CheckAndIncrement(sender2, quota)
+	if allowed1 || allowed2 {
+		t.Error("3rd message should be rejected for both senders")
+	}
+}
+
+func TestRateLimiter_GetCounts(t *testing.T) {
+	rl := &RateLimiter{
+		counters: make(map[string]*senderCounter),
+	}
+
+	sender := "test@example.org"
+	quota := &Quota{PerHour: 100, PerDay: 100}
+
+	// Send 5 messages
+	for i := 0; i < 5; i++ {
+		rl.CheckAndIncrement(sender, quota)
+	}
+
+	hourCount, dayCount := rl.GetCounts(sender)
+	if hourCount != 5 || dayCount != 5 {
+		t.Errorf("Expected counts to be 5, got hour=%d, day=%d", hourCount, dayCount)
+	}
+}
+
+func TestRateLimiter_GetCounts_NonexistentSender(t *testing.T) {
+	rl := &RateLimiter{
+		counters: make(map[string]*senderCounter),
+	}
+
+	hourCount, dayCount := rl.GetCounts("nonexistent@example.org")
+	if hourCount != 0 || dayCount != 0 {
+		t.Errorf("Expected counts to be 0 for nonexistent sender, got hour=%d, day=%d", hourCount, dayCount)
+	}
+}
+
+func TestRateLimiter_Cleanup(t *testing.T) {
+	rl := &RateLimiter{
+		counters: make(map[string]*senderCounter),
+	}
+
+	sender := "test@example.org"
+
+	// Add an old timestamp manually
+	rl.counters[sender] = &senderCounter{
+		timestamps: []time.Time{
+			time.Now().Add(-25 * time.Hour), // Older than 24 hours
+			time.Now().Add(-1 * time.Hour),  // Within 24 hours
+		},
+	}
+
+	rl.cleanup()
+
+	counter := rl.counters[sender]
+	if counter == nil {
+		t.Fatal("Counter should still exist")
+	}
+
+	if len(counter.timestamps) != 1 {
+		t.Errorf("Expected 1 timestamp after cleanup, got %d", len(counter.timestamps))
+	}
+}
+
+func TestRateLimiter_Cleanup_RemovesEmptySender(t *testing.T) {
+	rl := &RateLimiter{
+		counters: make(map[string]*senderCounter),
+	}
+
+	sender := "test@example.org"
+
+	// Add only old timestamps
+	rl.counters[sender] = &senderCounter{
+		timestamps: []time.Time{
+			time.Now().Add(-25 * time.Hour),
+			time.Now().Add(-26 * time.Hour),
+		},
+	}
+
+	rl.cleanup()
+
+	if _, exists := rl.counters[sender]; exists {
+		t.Error("Sender with only old timestamps should be removed")
+	}
+}
+
+func TestRateLimiter_SenderCount(t *testing.T) {
+	rl := &RateLimiter{
+		counters: make(map[string]*senderCounter),
+	}
+
+	quota := &Quota{PerHour: 100, PerDay: 100}
+
+	rl.CheckAndIncrement("user1@example.org", quota)
+	rl.CheckAndIncrement("user2@example.org", quota)
+	rl.CheckAndIncrement("user3@example.org", quota)
+
+	count := rl.SenderCount()
+	if count != 3 {
+		t.Errorf("Expected 3 tracked senders, got %d", count)
+	}
+}

--- a/userli.go
+++ b/userli.go
@@ -21,6 +21,13 @@ type UserliService interface {
 	GetDomain(ctx context.Context, domain string) (bool, error)
 	GetMailbox(ctx context.Context, email string) (bool, error)
 	GetSenders(ctx context.Context, email string) ([]string, error)
+	GetQuota(ctx context.Context, email string) (*Quota, error)
+}
+
+// Quota represents the sending quota limits for a user
+type Quota struct {
+	PerHour int `json:"per_hour"`
+	PerDay  int `json:"per_day"`
 }
 
 type Userli struct {
@@ -208,6 +215,28 @@ func (u *Userli) GetSenders(ctx context.Context, email string) ([]string, error)
 	}
 
 	return senders, nil
+}
+
+func (u *Userli) GetQuota(ctx context.Context, email string) (*Quota, error) {
+	sanitizedEmail, err := u.sanitizeEmail(email)
+	if err != nil {
+		logger.Info("unable to process the quota", zap.String("email", email), zap.Error(err))
+		return nil, err
+	}
+
+	resp, err := u.call(ctx, fmt.Sprintf("%s/api/postfix/quota/%s", u.baseURL, sanitizedEmail))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var quota Quota
+	err = json.NewDecoder(resp.Body).Decode(&quota)
+	if err != nil {
+		return nil, err
+	}
+
+	return &quota, nil
 }
 
 func (u *Userli) call(ctx context.Context, url string) (*http.Response, error) {

--- a/userli.go
+++ b/userli.go
@@ -224,7 +224,7 @@ func (u *Userli) GetQuota(ctx context.Context, email string) (*Quota, error) {
 		return nil, err
 	}
 
-	resp, err := u.call(ctx, fmt.Sprintf("%s/api/postfix/quota/%s", u.baseURL, sanitizedEmail))
+	resp, err := u.call(ctx, fmt.Sprintf("%s/api/postfix/smtp_quota/%s", u.baseURL, sanitizedEmail))
 	if err != nil {
 		return nil, err
 	}

--- a/userli_test.go
+++ b/userli_test.go
@@ -227,6 +227,68 @@ func (s *UserliTestSuite) TestGetSenders() {
 	})
 }
 
+func (s *UserliTestSuite) TestGetQuota() {
+	s.Run("success", func() {
+		gock.New("http://localhost:8000").
+			Get("/api/postfix/smtp_quota/user@example.com").
+			MatchHeader("Authorization", "Bearer insecure").
+			MatchHeader("Accept", "application/json").
+			MatchHeader("Content-Type", "application/json").
+			MatchHeader("User-Agent", "userli-postfix-adapter").
+			Reply(200).
+			JSON(map[string]int{"per_hour": 50, "per_day": 500})
+
+		quota, err := s.userli.GetQuota(context.Background(), "user@example.com")
+		s.NoError(err)
+		s.NotNil(quota)
+		s.Equal(50, quota.PerHour)
+		s.Equal(500, quota.PerDay)
+		s.True(gock.IsDone())
+	})
+
+	s.Run("no email", func() {
+		quota, err := s.userli.GetQuota(context.Background(), "user")
+		s.Error(err)
+		s.Nil(quota)
+	})
+
+	s.Run("server error", func() {
+		gock.New("http://localhost:8000").
+			Get("/api/postfix/smtp_quota/user@example.com").
+			MatchHeader("Authorization", "Bearer insecure").
+			MatchHeader("Accept", "application/json").
+			MatchHeader("Content-Type", "application/json").
+			MatchHeader("User-Agent", "userli-postfix-adapter").
+			Reply(500).
+			JSON(map[string]string{"error": "internal server error"})
+
+		// call() does not check HTTP status codes, so the response body
+		// is decoded into a Quota struct with zero values (no matching keys).
+		quota, err := s.userli.GetQuota(context.Background(), "user@example.com")
+		s.NoError(err)
+		s.NotNil(quota)
+		s.Equal(0, quota.PerHour)
+		s.Equal(0, quota.PerDay)
+		s.True(gock.IsDone())
+	})
+
+	s.Run("invalid json", func() {
+		gock.New("http://localhost:8000").
+			Get("/api/postfix/smtp_quota/user@example.com").
+			MatchHeader("Authorization", "Bearer insecure").
+			MatchHeader("Accept", "application/json").
+			MatchHeader("Content-Type", "application/json").
+			MatchHeader("User-Agent", "userli-postfix-adapter").
+			Reply(200).
+			BodyString("not valid json")
+
+		quota, err := s.userli.GetQuota(context.Background(), "user@example.com")
+		s.Error(err)
+		s.Nil(quota)
+		s.True(gock.IsDone())
+	})
+}
+
 func (s *UserliTestSuite) TestWithClient() {
 	s.Run("sets custom client", func() {
 		customClient := &http.Client{}


### PR DESCRIPTION
## Summary

- Add a Postfix SMTPD policy delegation server for rate limiting outgoing mail based on per-sender quotas
- Implement a sliding window rate limiter with per-hour and per-day limits
- Add `GetQuota` API endpoint to fetch sender quota limits from Userli

## Details

The policy server listens on port 10003 (configurable via `POLICY_LISTEN_ADDR`) and implements the [Postfix SMTPD Policy Delegation Protocol](http://www.postfix.org/SMTPD_POLICY_README.html). It:

1. Processes `END-OF-MESSAGE` protocol stage requests
2. Resolves sender identity (prefers SASL username over envelope sender)
3. Fetches per-hour/per-day quota from the Userli API
4. Enforces limits using a sliding window rate limiter with automatic cleanup

## Commits

| Commit | Description |
|---|---|
| ✨ GetQuota API | `Quota` struct, `GetQuota` on `UserliService` interface + implementation |
| ✨ Rate limiter | Sliding window rate limiter with per-sender timestamp tracking |
| ✨ Policy server | `PolicyServer` implementing `ConnectionHandler`, Prometheus metrics, config, main.go wiring |
| 📝 Documentation | README, docker-compose, copilot-instructions |

## Depends on

- #67 (Refactor: Extract generic TCP server and rename to LookupServer)

---

*This PR was generated with the assistance of OpenCode.*