### PR TITLE
🔊 Use named loggers to distinguish lookup and policy server in logs

### DIFF
--- a/lookup.go
+++ b/lookup.go
@@ -32,18 +32,20 @@ func (r *SocketmapResponse) String() string {
 // It implements the ConnectionHandler interface.
 type LookupServer struct {
 	client UserliService
+	logger *zap.Logger
 }
 
 // NewLookupServer creates a new LookupServer with the given UserliService
-func NewLookupServer(client UserliService) *LookupServer {
-	return &LookupServer{client: client}
+func NewLookupServer(client UserliService, logger *zap.Logger) *LookupServer {
+	return &LookupServer{client: client, logger: logger}
 }
 
 // StartLookupServer starts the lookup server on the given address
 func StartLookupServer(ctx context.Context, wg *sync.WaitGroup, addr string, server *LookupServer) {
 	config := TCPServerConfig{
-		Name: "socketmap",
-		Addr: addr,
+		Name:   "lookup",
+		Addr:   addr,
+		Logger: server.logger,
 		OnConnectionAcquired: func() {
 			activeConnections.Inc()
 		},
@@ -81,7 +83,7 @@ func (s *LookupServer) HandleConnection(ctx context.Context, conn net.Conn) {
 			if errors.As(err, &netErr) && netErr.Timeout() {
 				return
 			}
-			logger.Debug("Failed to decode request", zap.Error(err))
+			s.logger.Debug("Failed to decode request", zap.Error(err))
 			return
 		}
 		request := string(requestBytes)
@@ -91,7 +93,7 @@ func (s *LookupServer) HandleConnection(ctx context.Context, conn net.Conn) {
 		// Parse the request: "name key"
 		parts := strings.SplitN(strings.TrimSpace(request), " ", 2)
 		if len(parts) != 2 {
-			logger.Error("Invalid request format", zap.String("request", request))
+			s.logger.Error("Invalid request format", zap.String("request", request))
 			response := &SocketmapResponse{Status: "PERM", Data: "Invalid request format"}
 			s.writeResponse(encoder, conn, response, now, "invalid")
 			continue
@@ -100,7 +102,7 @@ func (s *LookupServer) HandleConnection(ctx context.Context, conn net.Conn) {
 		mapName := parts[0]
 		key := parts[1]
 
-		logger.Debug("Processing socketmap request",
+		s.logger.Debug("Processing socketmap request",
 			zap.String("map", mapName),
 			zap.String("key", key))
 
@@ -125,7 +127,7 @@ func (s *LookupServer) processRequest(ctx context.Context, mapName, key string) 
 	case "senders":
 		return s.handleSenders(reqCtx, key)
 	default:
-		logger.Error("Unknown map name", zap.String("map", mapName))
+		s.logger.Error("Unknown map name", zap.String("map", mapName))
 		return &SocketmapResponse{Status: "PERM", Data: "Unknown map name"}
 	}
 }
@@ -134,7 +136,7 @@ func (s *LookupServer) processRequest(ctx context.Context, mapName, key string) 
 func (s *LookupServer) handleAlias(ctx context.Context, key string) *SocketmapResponse {
 	aliases, err := s.client.GetAliases(ctx, key)
 	if err != nil {
-		logger.Error("Error fetching aliases", zap.String("key", key), zap.Error(err))
+		s.logger.Error("Error fetching aliases", zap.String("key", key), zap.Error(err))
 		return &SocketmapResponse{Status: "TEMP", Data: "Error fetching aliases"}
 	}
 
@@ -149,7 +151,7 @@ func (s *LookupServer) handleAlias(ctx context.Context, key string) *SocketmapRe
 func (s *LookupServer) handleDomain(ctx context.Context, key string) *SocketmapResponse {
 	exists, err := s.client.GetDomain(ctx, key)
 	if err != nil {
-		logger.Error("Error fetching domain", zap.String("key", key), zap.Error(err))
+		s.logger.Error("Error fetching domain", zap.String("key", key), zap.Error(err))
 		return &SocketmapResponse{Status: "TEMP", Data: "Error fetching domain"}
 	}
 
@@ -164,7 +166,7 @@ func (s *LookupServer) handleDomain(ctx context.Context, key string) *SocketmapR
 func (s *LookupServer) handleMailbox(ctx context.Context, key string) *SocketmapResponse {
 	exists, err := s.client.GetMailbox(ctx, key)
 	if err != nil {
-		logger.Error("Error fetching mailbox", zap.String("key", key), zap.Error(err))
+		s.logger.Error("Error fetching mailbox", zap.String("key", key), zap.Error(err))
 		return &SocketmapResponse{Status: "TEMP", Data: "Error fetching mailbox"}
 	}
 
@@ -179,7 +181,7 @@ func (s *LookupServer) handleMailbox(ctx context.Context, key string) *Socketmap
 func (s *LookupServer) handleSenders(ctx context.Context, key string) *SocketmapResponse {
 	senders, err := s.client.GetSenders(ctx, key)
 	if err != nil {
-		logger.Error("Error fetching senders", zap.String("key", key), zap.Error(err))
+		s.logger.Error("Error fetching senders", zap.String("key", key), zap.Error(err))
 		return &SocketmapResponse{Status: "TEMP", Data: "Error fetching senders"}
 	}
 
@@ -202,7 +204,7 @@ func (s *LookupServer) writeResponse(encoder *netstring.Encoder, conn net.Conn, 
 		status = "error"
 	}
 
-	logger.Debug("Writing socketmap response",
+	s.logger.Debug("Writing socketmap response",
 		zap.String("response", response.String()),
 		zap.String("map", mapName),
 		zap.String("status", status))
@@ -213,7 +215,7 @@ func (s *LookupServer) writeResponse(encoder *netstring.Encoder, conn net.Conn, 
 	// Encode and send the response
 	err := encoder.EncodeString(netstring.NoKey, response.String())
 	if err != nil {
-		logger.Error("Error writing response",
+		s.logger.Error("Error writing response",
 			zap.String("response", response.String()),
 			zap.String("map", mapName),
 			zap.String("status", status),

--- a/lookup_test.go
+++ b/lookup_test.go
@@ -49,7 +49,7 @@ func (s *ServerTestSuite) TearDownTest() {
 // TestStartLookupServer_BasicFunctionality tests basic server startup and shutdown
 func (s *ServerTestSuite) TestStartLookupServer_BasicFunctionality() {
 	mock := &MockUserliService{}
-	server := NewLookupServer(mock)
+	server := NewLookupServer(mock, zap.NewNop())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup
@@ -84,7 +84,7 @@ func (s *ServerTestSuite) TestStartLookupServer_BasicFunctionality() {
 // TestStartLookupServer_InvalidAddress tests server behavior with invalid address
 func (s *ServerTestSuite) TestStartLookupServer_InvalidAddress() {
 	mock := &MockUserliService{}
-	server := NewLookupServer(mock)
+	server := NewLookupServer(mock, zap.NewNop())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -116,7 +116,7 @@ func (s *ServerTestSuite) TestStartLookupServer_ConnectionHandling() {
 	mockService := &MockUserliService{}
 	// Mock a successful domain lookup
 	mockService.On("GetDomain", mock.Anything, "example.com").Return(true, nil)
-	server := NewLookupServer(mockService)
+	server := NewLookupServer(mockService, zap.NewNop())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -155,7 +155,7 @@ func (s *ServerTestSuite) TestStartLookupServer_ConnectionHandling() {
 // TestStartLookupServer_GracefulShutdown tests graceful shutdown with active connections
 func (s *ServerTestSuite) TestStartLookupServer_GracefulShutdown() {
 	mockService := &MockUserliService{}
-	server := NewLookupServer(mockService)
+	server := NewLookupServer(mockService, zap.NewNop())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup
@@ -207,7 +207,7 @@ func (s *ServerTestSuite) TestStartLookupServer_GracefulShutdown() {
 func (s *ServerTestSuite) TestHandleLookupConnection() {
 	mockService := &MockUserliService{}
 	mockService.On("GetDomain", mock.Anything, "example.com").Return(true, nil)
-	server := NewLookupServer(mockService)
+	server := NewLookupServer(mockService, zap.NewNop())
 
 	// Create a pipe to simulate a connection
 	serverConn, client := net.Pipe()
@@ -233,7 +233,7 @@ func (s *ServerTestSuite) TestHandleLookupConnection() {
 // TestStartLookupServer_ConnectionPoolLimit tests connection pool limits
 func (s *ServerTestSuite) TestStartLookupServer_ConnectionPoolLimit() {
 	mockService := &MockUserliService{}
-	server := NewLookupServer(mockService)
+	server := NewLookupServer(mockService, zap.NewNop())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -280,7 +280,7 @@ func (s *ServerTestSuite) TestHandleLookupConnection_MultipleRequests() {
 	mockService := &MockUserliService{}
 	mockService.On("GetDomain", mock.Anything, "example.com").Return(true, nil)
 	mockService.On("GetDomain", mock.Anything, "example.org").Return(false, nil)
-	server := NewLookupServer(mockService)
+	server := NewLookupServer(mockService, zap.NewNop())
 
 	serverConn, client := net.Pipe()
 	defer serverConn.Close()
@@ -318,7 +318,7 @@ func (s *ServerTestSuite) TestHandleLookupConnection_AliasLookup() {
 	mockService.On("GetAliases", mock.Anything, "alias@example.com").Return([]string{"user1@example.com", "user2@example.com"}, nil)
 	mockService.On("GetAliases", mock.Anything, "unknown@example.com").Return([]string{}, nil)
 	mockService.On("GetAliases", mock.Anything, "error@example.com").Return([]string(nil), io.ErrUnexpectedEOF)
-	server := NewLookupServer(mockService)
+	server := NewLookupServer(mockService, zap.NewNop())
 
 	serverConn, client := net.Pipe()
 	defer serverConn.Close()
@@ -356,7 +356,7 @@ func (s *ServerTestSuite) TestHandleLookupConnection_MailboxLookup() {
 	mockService.On("GetMailbox", mock.Anything, "user@example.com").Return(true, nil)
 	mockService.On("GetMailbox", mock.Anything, "unknown@example.com").Return(false, nil)
 	mockService.On("GetMailbox", mock.Anything, "error@example.com").Return(false, io.ErrUnexpectedEOF)
-	server := NewLookupServer(mockService)
+	server := NewLookupServer(mockService, zap.NewNop())
 
 	serverConn, client := net.Pipe()
 	defer serverConn.Close()
@@ -394,7 +394,7 @@ func (s *ServerTestSuite) TestHandleLookupConnection_SendersLookup() {
 	mockService.On("GetSenders", mock.Anything, "user@example.com").Return([]string{"alias1@example.com", "alias2@example.com"}, nil)
 	mockService.On("GetSenders", mock.Anything, "unknown@example.com").Return([]string{}, nil)
 	mockService.On("GetSenders", mock.Anything, "error@example.com").Return([]string(nil), io.ErrUnexpectedEOF)
-	server := NewLookupServer(mockService)
+	server := NewLookupServer(mockService, zap.NewNop())
 
 	serverConn, client := net.Pipe()
 	defer serverConn.Close()
@@ -430,7 +430,7 @@ func (s *ServerTestSuite) TestHandleLookupConnection_SendersLookup() {
 func (s *ServerTestSuite) TestHandleLookupConnection_DomainError() {
 	mockService := &MockUserliService{}
 	mockService.On("GetDomain", mock.Anything, "error.com").Return(false, io.ErrUnexpectedEOF)
-	server := NewLookupServer(mockService)
+	server := NewLookupServer(mockService, zap.NewNop())
 
 	serverConn, client := net.Pipe()
 	defer serverConn.Close()
@@ -450,7 +450,7 @@ func (s *ServerTestSuite) TestHandleLookupConnection_DomainError() {
 // TestHandleLookupConnection_UnknownMap tests unknown map name handling
 func (s *ServerTestSuite) TestHandleLookupConnection_UnknownMap() {
 	mockService := &MockUserliService{}
-	server := NewLookupServer(mockService)
+	server := NewLookupServer(mockService, zap.NewNop())
 
 	serverConn, client := net.Pipe()
 	defer serverConn.Close()
@@ -469,7 +469,7 @@ func (s *ServerTestSuite) TestHandleLookupConnection_UnknownMap() {
 // TestHandleLookupConnection_InvalidFormat tests invalid request format
 func (s *ServerTestSuite) TestHandleLookupConnection_InvalidFormat() {
 	mockService := &MockUserliService{}
-	server := NewLookupServer(mockService)
+	server := NewLookupServer(mockService, zap.NewNop())
 
 	serverConn, client := net.Pipe()
 	defer serverConn.Close()
@@ -489,7 +489,7 @@ func (s *ServerTestSuite) TestHandleLookupConnection_InvalidFormat() {
 // TestHandleLookupConnection_ContextCancelled tests context cancellation
 func (s *ServerTestSuite) TestHandleLookupConnection_ContextCancelled() {
 	mockService := &MockUserliService{}
-	server := NewLookupServer(mockService)
+	server := NewLookupServer(mockService, zap.NewNop())
 
 	serverConn, client := net.Pipe()
 

--- a/main.go
+++ b/main.go
@@ -42,13 +42,13 @@ func main() {
 	}
 
 	userli := NewUserli(config.UserliToken, config.UserliBaseURL, WithDelimiter(config.PostfixRecipientDelimiter))
-	lookupServer := NewLookupServer(userli)
+	lookupServer := NewLookupServer(userli, logger.Named("lookup"))
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
 	rateLimiter := NewRateLimiter(ctx)
-	policyServer := NewPolicyServer(userli, rateLimiter)
+	policyServer := NewPolicyServer(userli, rateLimiter, logger.Named("policy"))
 
 	var wg sync.WaitGroup
 

--- a/policy.go
+++ b/policy.go
@@ -18,21 +18,24 @@ import (
 type PolicyServer struct {
 	client      UserliService
 	rateLimiter *RateLimiter
+	logger      *zap.Logger
 }
 
 // NewPolicyServer creates a new PolicyServer with the given UserliService
-func NewPolicyServer(client UserliService, rateLimiter *RateLimiter) *PolicyServer {
+func NewPolicyServer(client UserliService, rateLimiter *RateLimiter, logger *zap.Logger) *PolicyServer {
 	return &PolicyServer{
 		client:      client,
 		rateLimiter: rateLimiter,
+		logger:      logger,
 	}
 }
 
 // StartPolicyServer starts the policy server on the given address
 func StartPolicyServer(ctx context.Context, wg *sync.WaitGroup, addr string, server *PolicyServer) {
 	config := TCPServerConfig{
-		Name: "policy",
-		Addr: addr,
+		Name:   "policy",
+		Addr:   addr,
+		Logger: server.logger,
 		OnConnectionAcquired: func() {
 			policyActiveConnections.Inc()
 		},
@@ -65,7 +68,7 @@ func (p *PolicyServer) HandleConnection(ctx context.Context, conn net.Conn) {
 			if errors.As(err, &netErr) && netErr.Timeout() {
 				return
 			}
-			logger.Debug("Failed to read policy request", zap.Error(err))
+			p.logger.Debug("Failed to read policy request", zap.Error(err))
 			return
 		}
 
@@ -73,7 +76,7 @@ func (p *PolicyServer) HandleConnection(ctx context.Context, conn net.Conn) {
 
 		_ = conn.SetWriteDeadline(time.Now().Add(WriteTimeout))
 		if err := p.writeResponse(conn, response); err != nil {
-			logger.Error("Failed to write policy response", zap.Error(err))
+			p.logger.Error("Failed to write policy response", zap.Error(err))
 			return
 		}
 	}
@@ -162,7 +165,7 @@ func (p *PolicyServer) readRequest(reader *bufio.Reader) (*PolicyRequest, error)
 func (p *PolicyServer) handleRequest(ctx context.Context, req *PolicyRequest) string {
 	startTime := time.Now()
 
-	logger.Debug("Processing policy request",
+	p.logger.Debug("Processing policy request",
 		zap.String("queue_id", req.QueueID),
 		zap.String("sender", req.Sender),
 		zap.String("sasl_username", req.SaslUsername),
@@ -184,7 +187,7 @@ func (p *PolicyServer) handleRequest(ctx context.Context, req *PolicyRequest) st
 	}
 
 	if sender == "" {
-		logger.Debug("No sender identity found, allowing message")
+		p.logger.Debug("No sender identity found, allowing message")
 		policyRequestsTotal.WithLabelValues("check", "dunno").Inc()
 		policyRequestDuration.WithLabelValues("check", "dunno").Observe(time.Since(startTime).Seconds())
 		return "DUNNO"
@@ -197,7 +200,7 @@ func (p *PolicyServer) handleRequest(ctx context.Context, req *PolicyRequest) st
 	quota, err := p.client.GetQuota(quotaCtx, sender)
 	if err != nil {
 		// API error - fail open (allow the message)
-		logger.Warn("Failed to fetch quota, allowing message",
+		p.logger.Warn("Failed to fetch quota, allowing message",
 			zap.String("queue_id", req.QueueID),
 			zap.String("sender", sender), zap.Error(err))
 		policyRequestsTotal.WithLabelValues("check", "error").Inc()
@@ -207,7 +210,7 @@ func (p *PolicyServer) handleRequest(ctx context.Context, req *PolicyRequest) st
 
 	// No limits configured (both 0 means unlimited)
 	if quota.PerHour == 0 && quota.PerDay == 0 {
-		logger.Debug("No quota limits configured", zap.String("sender", sender))
+		p.logger.Debug("No quota limits configured", zap.String("sender", sender))
 		policyRequestsTotal.WithLabelValues("check", "dunno").Inc()
 		policyRequestDuration.WithLabelValues("check", "dunno").Observe(time.Since(startTime).Seconds())
 		return "DUNNO"
@@ -220,7 +223,7 @@ func (p *PolicyServer) handleRequest(ctx context.Context, req *PolicyRequest) st
 	quotaChecksTotal.WithLabelValues("checked").Inc()
 
 	if !allowed {
-		logger.Info("Rate limit exceeded",
+		p.logger.Info("Rate limit exceeded",
 			zap.String("queue_id", req.QueueID),
 			zap.String("sender", sender),
 			zap.Int("hour_count", hourCount),
@@ -235,7 +238,7 @@ func (p *PolicyServer) handleRequest(ctx context.Context, req *PolicyRequest) st
 		return "REJECT Rate limit exceeded, please try again later"
 	}
 
-	logger.Debug("Message allowed",
+	p.logger.Debug("Message allowed",
 		zap.String("queue_id", req.QueueID),
 		zap.String("sender", sender),
 		zap.Int("hour_count", hourCount),

--- a/policy_test.go
+++ b/policy_test.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"go.uber.org/zap"
 )
 
 // MockUserliService is a mock implementation for testing
@@ -79,7 +81,7 @@ func TestPolicyServer_HandleRequest_SkipNonEndOfMessage(t *testing.T) {
 	rateLimiter := &RateLimiter{
 		counters: make(map[string]*senderCounter),
 	}
-	server := NewPolicyServer(mockClient, rateLimiter)
+	server := NewPolicyServer(mockClient, rateLimiter, zap.NewNop())
 
 	req := &PolicyRequest{
 		ProtocolState: "RCPT",
@@ -101,7 +103,7 @@ func TestPolicyServer_HandleRequest_NoSender(t *testing.T) {
 	rateLimiter := &RateLimiter{
 		counters: make(map[string]*senderCounter),
 	}
-	server := NewPolicyServer(mockClient, rateLimiter)
+	server := NewPolicyServer(mockClient, rateLimiter, zap.NewNop())
 
 	req := &PolicyRequest{
 		ProtocolState: "END-OF-MESSAGE",
@@ -123,7 +125,7 @@ func TestPolicyServer_HandleRequest_APIError(t *testing.T) {
 	rateLimiter := &RateLimiter{
 		counters: make(map[string]*senderCounter),
 	}
-	server := NewPolicyServer(mockClient, rateLimiter)
+	server := NewPolicyServer(mockClient, rateLimiter, zap.NewNop())
 
 	req := &PolicyRequest{
 		ProtocolState: "END-OF-MESSAGE",
@@ -146,7 +148,7 @@ func TestPolicyServer_HandleRequest_NoLimits(t *testing.T) {
 	rateLimiter := &RateLimiter{
 		counters: make(map[string]*senderCounter),
 	}
-	server := NewPolicyServer(mockClient, rateLimiter)
+	server := NewPolicyServer(mockClient, rateLimiter, zap.NewNop())
 
 	req := &PolicyRequest{
 		ProtocolState: "END-OF-MESSAGE",
@@ -168,7 +170,7 @@ func TestPolicyServer_HandleRequest_AllowedMessage(t *testing.T) {
 	rateLimiter := &RateLimiter{
 		counters: make(map[string]*senderCounter),
 	}
-	server := NewPolicyServer(mockClient, rateLimiter)
+	server := NewPolicyServer(mockClient, rateLimiter, zap.NewNop())
 
 	req := &PolicyRequest{
 		ProtocolState: "END-OF-MESSAGE",
@@ -190,7 +192,7 @@ func TestPolicyServer_HandleRequest_RateLimited(t *testing.T) {
 	rateLimiter := &RateLimiter{
 		counters: make(map[string]*senderCounter),
 	}
-	server := NewPolicyServer(mockClient, rateLimiter)
+	server := NewPolicyServer(mockClient, rateLimiter, zap.NewNop())
 
 	req := &PolicyRequest{
 		ProtocolState: "END-OF-MESSAGE",
@@ -223,7 +225,7 @@ func TestPolicyServer_HandleRequest_UsesSaslUsername(t *testing.T) {
 	rateLimiter := &RateLimiter{
 		counters: make(map[string]*senderCounter),
 	}
-	server := NewPolicyServer(mockClient, rateLimiter)
+	server := NewPolicyServer(mockClient, rateLimiter, zap.NewNop())
 
 	// First request uses sasl_username
 	req1 := &PolicyRequest{
@@ -253,7 +255,7 @@ func TestPolicyServer_Integration(t *testing.T) {
 	rateLimiter := &RateLimiter{
 		counters: make(map[string]*senderCounter),
 	}
-	server := NewPolicyServer(mockClient, rateLimiter)
+	server := NewPolicyServer(mockClient, rateLimiter, zap.NewNop())
 
 	// Start server on random port
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
@@ -315,7 +317,7 @@ func TestPolicyServer_HandleConnection(t *testing.T) {
 	rateLimiter := &RateLimiter{
 		counters: make(map[string]*senderCounter),
 	}
-	server := NewPolicyServer(mockClient, rateLimiter)
+	server := NewPolicyServer(mockClient, rateLimiter, zap.NewNop())
 
 	serverConn, clientConn := net.Pipe()
 	defer serverConn.Close()
@@ -365,7 +367,7 @@ func TestPolicyServer_HandleConnection_MultipleRequests(t *testing.T) {
 	rateLimiter := &RateLimiter{
 		counters: make(map[string]*senderCounter),
 	}
-	server := NewPolicyServer(mockClient, rateLimiter)
+	server := NewPolicyServer(mockClient, rateLimiter, zap.NewNop())
 
 	serverConn, clientConn := net.Pipe()
 	defer serverConn.Close()
@@ -410,7 +412,7 @@ func TestPolicyServer_StartPolicyServer(t *testing.T) {
 	rateLimiter := &RateLimiter{
 		counters: make(map[string]*senderCounter),
 	}
-	server := NewPolicyServer(mockClient, rateLimiter)
+	server := NewPolicyServer(mockClient, rateLimiter, zap.NewNop())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup

--- a/tcpserver.go
+++ b/tcpserver.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -23,6 +22,7 @@ const (
 type TCPServerConfig struct {
 	Name                 string
 	Addr                 string
+	Logger               *zap.Logger
 	OnConnectionAcquired func()
 	OnConnectionReleased func()
 	OnConnectionPoolFull func()
@@ -55,7 +55,7 @@ func StartTCPServer(ctx context.Context, wg *sync.WaitGroup, config TCPServerCon
 
 	listener, err := lc.Listen(ctx, "tcp", config.Addr)
 	if err != nil {
-		logger.Error(fmt.Sprintf("Failed to create %s listener", config.Name),
+		config.Logger.Error("Failed to create listener",
 			zap.String("addr", config.Addr), zap.Error(err))
 		return
 	}
@@ -64,15 +64,15 @@ func StartTCPServer(ctx context.Context, wg *sync.WaitGroup, config TCPServerCon
 	// Graceful shutdown handler
 	go func() {
 		<-ctx.Done()
-		logger.Info(fmt.Sprintf("Shutting down %s server...", config.Name),
+		config.Logger.Info("Shutting down server...",
 			zap.String("addr", config.Addr))
 		listener.Close()
 		activeConnWg.Wait()
-		logger.Info(fmt.Sprintf("All %s connections closed", config.Name),
+		config.Logger.Info("All connections closed",
 			zap.String("addr", config.Addr))
 	}()
 
-	logger.Info(fmt.Sprintf("%s server started", config.Name),
+	config.Logger.Info("Server started",
 		zap.String("addr", config.Addr))
 
 	for {
@@ -81,7 +81,7 @@ func StartTCPServer(ctx context.Context, wg *sync.WaitGroup, config TCPServerCon
 			if ctx.Err() != nil {
 				return
 			}
-			logger.Error("Accept failed",
+			config.Logger.Error("Accept failed",
 				zap.String("addr", config.Addr), zap.Error(err))
 			continue
 		}
@@ -99,7 +99,7 @@ func StartTCPServer(ctx context.Context, wg *sync.WaitGroup, config TCPServerCon
 			}
 			go handleTCPConnection(ctx, conn, handler, connSemaphore, &activeConnWg, cb)
 		default:
-			logger.Warn(fmt.Sprintf("Connection pool full, rejecting %s connection", config.Name),
+			config.Logger.Warn("Connection pool full, rejecting connection",
 				zap.String("addr", config.Addr))
 			if config.OnConnectionPoolFull != nil {
 				config.OnConnectionPoolFull()


### PR DESCRIPTION
## Summary

- Add `*zap.Logger` field to `LookupServer`, `PolicyServer`, and `TCPServerConfig` using `zap.Named()` to tag all log output with `"logger":"lookup"` or `"logger":"policy"`
- Remove `fmt.Sprintf` wrapping for server names in `tcpserver.go` log messages since the named logger makes them redundant
- Pass `zap.NewNop()` in tests to satisfy the new constructor signatures

---
<sub>The changes and the PR were generated by OpenCode.</sub>