### PR TITLE
:bug: Count rejected requests in rate limiter sliding window

### DIFF
--- a/ratelimit.go
+++ b/ratelimit.go
@@ -74,18 +74,20 @@ func (rl *RateLimiter) CheckAndIncrement(sender string, quota *Quota) (allowed b
 
 	counter.timestamps = validTimestamps
 
-	// Check limits (0 means unlimited)
-	if quota.PerHour > 0 && hourCount >= quota.PerHour {
-		return false, hourCount, dayCount
-	}
-	if quota.PerDay > 0 && dayCount >= quota.PerDay {
-		return false, hourCount, dayCount
-	}
-
-	// Add new timestamp
+	// Always record the current request (even if rejected) so that
+	// senders who keep trying while over-limit extend their own window
+	// instead of getting a free reset once old timestamps expire.
 	counter.timestamps = append(counter.timestamps, now)
 	hourCount++
 	dayCount++
+
+	// Check limits (0 means unlimited)
+	if quota.PerHour > 0 && hourCount > quota.PerHour {
+		return false, hourCount, dayCount
+	}
+	if quota.PerDay > 0 && dayCount > quota.PerDay {
+		return false, hourCount, dayCount
+	}
 
 	return true, hourCount, dayCount
 }

--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -52,13 +52,13 @@ func TestRateLimiter_CheckAndIncrement_HourlyLimit(t *testing.T) {
 		}
 	}
 
-	// 4th message should be rejected
+	// 4th message should be rejected but still counted
 	allowed, hourCount, _ := rl.CheckAndIncrement(sender, quota)
 	if allowed {
 		t.Error("4th message should be rejected due to hourly limit")
 	}
-	if hourCount != 3 {
-		t.Errorf("Expected hourCount to be 3, got %d", hourCount)
+	if hourCount != 4 {
+		t.Errorf("Expected hourCount to be 4, got %d", hourCount)
 	}
 }
 
@@ -78,13 +78,13 @@ func TestRateLimiter_CheckAndIncrement_DailyLimit(t *testing.T) {
 		}
 	}
 
-	// 4th message should be rejected
+	// 4th message should be rejected but still counted
 	allowed, _, dayCount := rl.CheckAndIncrement(sender, quota)
 	if allowed {
 		t.Error("4th message should be rejected due to daily limit")
 	}
-	if dayCount != 3 {
-		t.Errorf("Expected dayCount to be 3, got %d", dayCount)
+	if dayCount != 4 {
+		t.Errorf("Expected dayCount to be 4, got %d", dayCount)
 	}
 }
 
@@ -111,6 +111,42 @@ func TestRateLimiter_CheckAndIncrement_MultipleSenders(t *testing.T) {
 	allowed2, _, _ := rl.CheckAndIncrement(sender2, quota)
 	if allowed1 || allowed2 {
 		t.Error("3rd message should be rejected for both senders")
+	}
+}
+
+func TestRateLimiter_CheckAndIncrement_RejectedRequestsExtendWindow(t *testing.T) {
+	rl := &RateLimiter{
+		counters: make(map[string]*senderCounter),
+	}
+
+	quota := &Quota{PerHour: 2, PerDay: 100}
+	sender := "spammer@example.org"
+
+	// Use up the hourly quota
+	for i := 0; i < 2; i++ {
+		allowed, _, _ := rl.CheckAndIncrement(sender, quota)
+		if !allowed {
+			t.Errorf("Message %d should be allowed", i+1)
+		}
+	}
+
+	// Simulate continued spam attempts while over limit.
+	// Each rejected request should still be recorded so the sender
+	// cannot simply wait for the oldest timestamps to expire.
+	for i := 0; i < 5; i++ {
+		allowed, _, _ := rl.CheckAndIncrement(sender, quota)
+		if allowed {
+			t.Errorf("Spam attempt %d should be rejected", i+1)
+		}
+	}
+
+	// Verify that rejected attempts were counted
+	hourCount, dayCount := rl.GetCounts(sender)
+	if hourCount != 7 {
+		t.Errorf("Expected hourCount to include rejected attempts (7), got %d", hourCount)
+	}
+	if dayCount != 7 {
+		t.Errorf("Expected dayCount to include rejected attempts (7), got %d", dayCount)
 	}
 }
 


### PR DESCRIPTION
## Summary

Previously, rejected requests were not recorded in the rate limiter's sliding window. This meant that senders who exceeded their quota could simply keep sending — once the oldest timestamps expired, they would immediately regain their full quota without any penalty for the continued attempts.

This fix records all requests (including rejected ones) in the sliding window, so senders who keep trying while over-limit extend their own blocking period. A sender must stop sending entirely for the window duration before their quota resets.

### Changes

- Always append a timestamp in `CheckAndIncrement`, regardless of whether the request is allowed or rejected
- Adjust limit comparisons from `>=` to `>` since the current request is now counted before checking
- Add test `TestRateLimiter_CheckAndIncrement_RejectedRequestsExtendWindow` validating penalty behavior
- Update existing test expectations for the new counting semantics

---
<sub>The changes and the PR were generated by OpenCode.</sub>