### PR TITLE
:zap: Cache successful lookup responses in Redis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,8 @@ SENDERS_LISTEN_ADDR=":10004"
 METRICS_LISTEN_ADDR=":10005"
 RATE_LIMIT_MESSAGE="Rate limit exceeded, please try again later"
 REDIS_URL="redis://redis:6379/0"
+# TTL for cached successful lookup responses (Go duration; "0" disables).
+LOOKUP_CACHE_TTL=300s
 
 LOG_LEVEL=debug
 LOG_FORMAT=text

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The adapter is configured via environment variables:
 - `METRICS_LISTEN_ADDR`: The address to listen on for metrics. Default: `:10002`.
 - `RATE_LIMIT_MESSAGE`: The rejection message returned when a sender exceeds their quota. Default: `Rate limit exceeded, please try again later`.
 - `REDIS_URL`: Connection URL for Redis (required). Format follows [`redis.ParseURL`](https://pkg.go.dev/github.com/redis/go-redis/v9#ParseURL), e.g. `redis://[user:password@]host:port/db`. Rate-limit state is stored in Redis so it survives restarts.
+- `LOOKUP_CACHE_TTL`: TTL for cached successful (`OK`) lookup responses in Redis. Accepts any [Go duration](https://pkg.go.dev/time#ParseDuration) (e.g. `300s`, `5m`). Default: `300s`. Set to `0` to disable the cache. `NOTFOUND`/`TEMP`/`PERM` responses are never cached.
 
 In Postfix, you can configure the adapter using the socketmap protocol like this:
 

--- a/config.go
+++ b/config.go
@@ -3,7 +3,12 @@ package main
 import (
 	"fmt"
 	"os"
+	"time"
 )
+
+// defaultLookupCacheTTL is the default TTL for cached successful lookups when
+// LOOKUP_CACHE_TTL is not set. Setting LOOKUP_CACHE_TTL=0 disables the cache.
+const defaultLookupCacheTTL = 300 * time.Second
 
 // Config is the configuration for the application.
 type Config struct {
@@ -28,8 +33,13 @@ type Config struct {
 	// RateLimitMessage is the message returned when rate limit is exceeded.
 	RateLimitMessage string
 
-	// RedisURL is the connection URL for Redis (used to persist rate-limit state).
+	// RedisURL is the connection URL for Redis (used to persist rate-limit state
+	// and cache successful lookup responses).
 	RedisURL string
+
+	// LookupCacheTTL is the TTL for cached successful lookup responses.
+	// Zero disables caching entirely.
+	LookupCacheTTL time.Duration
 }
 
 // NewConfig creates a new Config with default values.
@@ -71,6 +81,18 @@ func NewConfig() (*Config, error) {
 		return nil, fmt.Errorf("REDIS_URL is required")
 	}
 
+	lookupCacheTTL := defaultLookupCacheTTL
+	if raw := os.Getenv("LOOKUP_CACHE_TTL"); raw != "" {
+		parsed, err := time.ParseDuration(raw)
+		if err != nil {
+			return nil, fmt.Errorf("LOOKUP_CACHE_TTL: %w", err)
+		}
+		if parsed < 0 {
+			return nil, fmt.Errorf("LOOKUP_CACHE_TTL must be non-negative")
+		}
+		lookupCacheTTL = parsed
+	}
+
 	return &Config{
 		UserliBaseURL:             userliBaseURL,
 		UserliToken:               userliToken,
@@ -80,5 +102,6 @@ func NewConfig() (*Config, error) {
 		MetricsListenAddr:         metricsListenAddr,
 		RateLimitMessage:          rateLimitMessage,
 		RedisURL:                  redisURL,
+		LookupCacheTTL:            lookupCacheTTL,
 	}, nil
 }

--- a/lookup.go
+++ b/lookup.go
@@ -32,12 +32,14 @@ func (r *SocketmapResponse) String() string {
 // It implements the ConnectionHandler interface.
 type LookupServer struct {
 	client UserliService
+	cache  *LookupCache
 	logger *zap.Logger
 }
 
-// NewLookupServer creates a new LookupServer with the given UserliService
-func NewLookupServer(client UserliService, logger *zap.Logger) *LookupServer {
-	return &LookupServer{client: client, logger: logger}
+// NewLookupServer creates a new LookupServer with the given UserliService and
+// optional LookupCache. A nil cache disables caching entirely.
+func NewLookupServer(client UserliService, cache *LookupCache, logger *zap.Logger) *LookupServer {
+	return &LookupServer{client: client, cache: cache, logger: logger}
 }
 
 // StartLookupServer starts the lookup server on the given address
@@ -113,23 +115,32 @@ func (s *LookupServer) HandleConnection(ctx context.Context, conn net.Conn) {
 
 // processRequest routes a socketmap request to the appropriate handler with a timeout context.
 // Using a separate method ensures defer cancel() runs after each request, preventing context leaks.
+// Successful (OK) responses are cached so repeated lookups skip the upstream API.
 func (s *LookupServer) processRequest(ctx context.Context, mapName, key string) *SocketmapResponse {
 	reqCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
+	if cached, ok := s.cache.Get(reqCtx, mapName, key); ok {
+		return cached
+	}
+
+	var response *SocketmapResponse
 	switch mapName {
 	case "alias":
-		return s.handleAlias(reqCtx, key)
+		response = s.handleAlias(reqCtx, key)
 	case "domain":
-		return s.handleDomain(reqCtx, key)
+		response = s.handleDomain(reqCtx, key)
 	case "mailbox":
-		return s.handleMailbox(reqCtx, key)
+		response = s.handleMailbox(reqCtx, key)
 	case "senders":
-		return s.handleSenders(reqCtx, key)
+		response = s.handleSenders(reqCtx, key)
 	default:
 		s.logger.Error("Unknown map name", zap.String("map", mapName))
 		return &SocketmapResponse{Status: "PERM", Data: "Unknown map name"}
 	}
+
+	s.cache.Set(reqCtx, mapName, key, response)
+	return response
 }
 
 // handleAlias processes alias lookup requests

--- a/lookup_test.go
+++ b/lookup_test.go
@@ -49,7 +49,7 @@ func (s *ServerTestSuite) TearDownTest() {
 // TestStartLookupServer_BasicFunctionality tests basic server startup and shutdown
 func (s *ServerTestSuite) TestStartLookupServer_BasicFunctionality() {
 	mock := &MockUserliService{}
-	server := NewLookupServer(mock, zap.NewNop())
+	server := NewLookupServer(mock, nil, zap.NewNop())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup
@@ -84,7 +84,7 @@ func (s *ServerTestSuite) TestStartLookupServer_BasicFunctionality() {
 // TestStartLookupServer_InvalidAddress tests server behavior with invalid address
 func (s *ServerTestSuite) TestStartLookupServer_InvalidAddress() {
 	mock := &MockUserliService{}
-	server := NewLookupServer(mock, zap.NewNop())
+	server := NewLookupServer(mock, nil, zap.NewNop())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -116,7 +116,7 @@ func (s *ServerTestSuite) TestStartLookupServer_ConnectionHandling() {
 	mockService := &MockUserliService{}
 	// Mock a successful domain lookup
 	mockService.On("GetDomain", mock.Anything, "example.com").Return(true, nil)
-	server := NewLookupServer(mockService, zap.NewNop())
+	server := NewLookupServer(mockService, nil, zap.NewNop())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -155,7 +155,7 @@ func (s *ServerTestSuite) TestStartLookupServer_ConnectionHandling() {
 // TestStartLookupServer_GracefulShutdown tests graceful shutdown with active connections
 func (s *ServerTestSuite) TestStartLookupServer_GracefulShutdown() {
 	mockService := &MockUserliService{}
-	server := NewLookupServer(mockService, zap.NewNop())
+	server := NewLookupServer(mockService, nil, zap.NewNop())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup
@@ -207,7 +207,7 @@ func (s *ServerTestSuite) TestStartLookupServer_GracefulShutdown() {
 func (s *ServerTestSuite) TestHandleLookupConnection() {
 	mockService := &MockUserliService{}
 	mockService.On("GetDomain", mock.Anything, "example.com").Return(true, nil)
-	server := NewLookupServer(mockService, zap.NewNop())
+	server := NewLookupServer(mockService, nil, zap.NewNop())
 
 	// Create a pipe to simulate a connection
 	serverConn, client := net.Pipe()
@@ -233,7 +233,7 @@ func (s *ServerTestSuite) TestHandleLookupConnection() {
 // TestStartLookupServer_ConnectionPoolLimit tests connection pool limits
 func (s *ServerTestSuite) TestStartLookupServer_ConnectionPoolLimit() {
 	mockService := &MockUserliService{}
-	server := NewLookupServer(mockService, zap.NewNop())
+	server := NewLookupServer(mockService, nil, zap.NewNop())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -280,7 +280,7 @@ func (s *ServerTestSuite) TestHandleLookupConnection_MultipleRequests() {
 	mockService := &MockUserliService{}
 	mockService.On("GetDomain", mock.Anything, "example.com").Return(true, nil)
 	mockService.On("GetDomain", mock.Anything, "example.org").Return(false, nil)
-	server := NewLookupServer(mockService, zap.NewNop())
+	server := NewLookupServer(mockService, nil, zap.NewNop())
 
 	serverConn, client := net.Pipe()
 	defer serverConn.Close()
@@ -318,7 +318,7 @@ func (s *ServerTestSuite) TestHandleLookupConnection_AliasLookup() {
 	mockService.On("GetAliases", mock.Anything, "alias@example.com").Return([]string{"user1@example.com", "user2@example.com"}, nil)
 	mockService.On("GetAliases", mock.Anything, "unknown@example.com").Return([]string{}, nil)
 	mockService.On("GetAliases", mock.Anything, "error@example.com").Return([]string(nil), io.ErrUnexpectedEOF)
-	server := NewLookupServer(mockService, zap.NewNop())
+	server := NewLookupServer(mockService, nil, zap.NewNop())
 
 	serverConn, client := net.Pipe()
 	defer serverConn.Close()
@@ -356,7 +356,7 @@ func (s *ServerTestSuite) TestHandleLookupConnection_MailboxLookup() {
 	mockService.On("GetMailbox", mock.Anything, "user@example.com").Return(true, nil)
 	mockService.On("GetMailbox", mock.Anything, "unknown@example.com").Return(false, nil)
 	mockService.On("GetMailbox", mock.Anything, "error@example.com").Return(false, io.ErrUnexpectedEOF)
-	server := NewLookupServer(mockService, zap.NewNop())
+	server := NewLookupServer(mockService, nil, zap.NewNop())
 
 	serverConn, client := net.Pipe()
 	defer serverConn.Close()
@@ -394,7 +394,7 @@ func (s *ServerTestSuite) TestHandleLookupConnection_SendersLookup() {
 	mockService.On("GetSenders", mock.Anything, "user@example.com").Return([]string{"alias1@example.com", "alias2@example.com"}, nil)
 	mockService.On("GetSenders", mock.Anything, "unknown@example.com").Return([]string{}, nil)
 	mockService.On("GetSenders", mock.Anything, "error@example.com").Return([]string(nil), io.ErrUnexpectedEOF)
-	server := NewLookupServer(mockService, zap.NewNop())
+	server := NewLookupServer(mockService, nil, zap.NewNop())
 
 	serverConn, client := net.Pipe()
 	defer serverConn.Close()
@@ -430,7 +430,7 @@ func (s *ServerTestSuite) TestHandleLookupConnection_SendersLookup() {
 func (s *ServerTestSuite) TestHandleLookupConnection_DomainError() {
 	mockService := &MockUserliService{}
 	mockService.On("GetDomain", mock.Anything, "error.com").Return(false, io.ErrUnexpectedEOF)
-	server := NewLookupServer(mockService, zap.NewNop())
+	server := NewLookupServer(mockService, nil, zap.NewNop())
 
 	serverConn, client := net.Pipe()
 	defer serverConn.Close()
@@ -450,7 +450,7 @@ func (s *ServerTestSuite) TestHandleLookupConnection_DomainError() {
 // TestHandleLookupConnection_UnknownMap tests unknown map name handling
 func (s *ServerTestSuite) TestHandleLookupConnection_UnknownMap() {
 	mockService := &MockUserliService{}
-	server := NewLookupServer(mockService, zap.NewNop())
+	server := NewLookupServer(mockService, nil, zap.NewNop())
 
 	serverConn, client := net.Pipe()
 	defer serverConn.Close()
@@ -469,7 +469,7 @@ func (s *ServerTestSuite) TestHandleLookupConnection_UnknownMap() {
 // TestHandleLookupConnection_InvalidFormat tests invalid request format
 func (s *ServerTestSuite) TestHandleLookupConnection_InvalidFormat() {
 	mockService := &MockUserliService{}
-	server := NewLookupServer(mockService, zap.NewNop())
+	server := NewLookupServer(mockService, nil, zap.NewNop())
 
 	serverConn, client := net.Pipe()
 	defer serverConn.Close()
@@ -489,7 +489,7 @@ func (s *ServerTestSuite) TestHandleLookupConnection_InvalidFormat() {
 // TestHandleLookupConnection_ContextCancelled tests context cancellation
 func (s *ServerTestSuite) TestHandleLookupConnection_ContextCancelled() {
 	mockService := &MockUserliService{}
-	server := NewLookupServer(mockService, zap.NewNop())
+	server := NewLookupServer(mockService, nil, zap.NewNop())
 
 	serverConn, client := net.Pipe()
 
@@ -513,6 +513,114 @@ func (s *ServerTestSuite) TestHandleLookupConnection_ContextCancelled() {
 	case <-time.After(2 * time.Second):
 		s.Fail("Handler did not exit after context cancellation")
 	}
+}
+
+// TestHandleLookupConnection_CacheHitSkipsAPI verifies that a cached OK
+// response short-circuits the handler without calling UserliService.
+func (s *ServerTestSuite) TestHandleLookupConnection_CacheHitSkipsAPI() {
+	cache, mr := newTestLookupCache(s.T())
+	// Pre-seed the cache; key format must match LookupCache.keyFor.
+	mr.Set(lookupCacheKeyPrefix+"domain:example.com", "OK 1")
+
+	mockService := &MockUserliService{}
+	server := NewLookupServer(mockService, cache, zap.NewNop())
+
+	serverConn, client := net.Pipe()
+	defer serverConn.Close()
+	defer client.Close()
+
+	go server.HandleConnection(context.Background(), serverConn)
+
+	_, err := client.Write(s.encodeNetstring("domain example.com"))
+	s.Require().NoError(err)
+	response, err := s.readNetstringResponse(client)
+	s.Require().NoError(err)
+	s.Contains(response, "OK 1")
+
+	// Mock had no expectations registered — assert none were called.
+	mockService.AssertExpectations(s.T())
+	mockService.AssertNotCalled(s.T(), "GetDomain")
+}
+
+// TestHandleLookupConnection_CachePopulatesOnMiss verifies that a successful
+// API lookup writes its response into Redis.
+func (s *ServerTestSuite) TestHandleLookupConnection_CachePopulatesOnMiss() {
+	cache, mr := newTestLookupCache(s.T())
+
+	mockService := &MockUserliService{}
+	mockService.On("GetAliases", mock.Anything, "alias@example.com").
+		Return([]string{"user1@example.com", "user2@example.com"}, nil)
+	server := NewLookupServer(mockService, cache, zap.NewNop())
+
+	serverConn, client := net.Pipe()
+	defer serverConn.Close()
+	defer client.Close()
+
+	go server.HandleConnection(context.Background(), serverConn)
+
+	_, err := client.Write(s.encodeNetstring("alias alias@example.com"))
+	s.Require().NoError(err)
+	_, err = s.readNetstringResponse(client)
+	s.Require().NoError(err)
+
+	cached, err := mr.Get(lookupCacheKeyPrefix + "alias:alias@example.com")
+	s.Require().NoError(err)
+	s.Equal("OK user1@example.com,user2@example.com", cached)
+
+	mockService.AssertExpectations(s.T())
+}
+
+// TestHandleLookupConnection_NotFoundIsNotCached ensures NOTFOUND responses
+// do not get stored — newly-created entries must become visible immediately.
+func (s *ServerTestSuite) TestHandleLookupConnection_NotFoundIsNotCached() {
+	cache, mr := newTestLookupCache(s.T())
+
+	mockService := &MockUserliService{}
+	mockService.On("GetMailbox", mock.Anything, "missing@example.com").Return(false, nil)
+	server := NewLookupServer(mockService, cache, zap.NewNop())
+
+	serverConn, client := net.Pipe()
+	defer serverConn.Close()
+	defer client.Close()
+
+	go server.HandleConnection(context.Background(), serverConn)
+
+	_, err := client.Write(s.encodeNetstring("mailbox missing@example.com"))
+	s.Require().NoError(err)
+	response, err := s.readNetstringResponse(client)
+	s.Require().NoError(err)
+	s.Contains(response, "NOTFOUND")
+
+	s.False(mr.Exists(lookupCacheKeyPrefix+"mailbox:missing@example.com"),
+		"NOTFOUND must not be cached")
+	mockService.AssertExpectations(s.T())
+}
+
+// TestHandleLookupConnection_TempIsNotCached ensures upstream errors are not
+// cached so the next request retries.
+func (s *ServerTestSuite) TestHandleLookupConnection_TempIsNotCached() {
+	cache, mr := newTestLookupCache(s.T())
+
+	mockService := &MockUserliService{}
+	mockService.On("GetDomain", mock.Anything, "broken.test").
+		Return(false, io.ErrUnexpectedEOF)
+	server := NewLookupServer(mockService, cache, zap.NewNop())
+
+	serverConn, client := net.Pipe()
+	defer serverConn.Close()
+	defer client.Close()
+
+	go server.HandleConnection(context.Background(), serverConn)
+
+	_, err := client.Write(s.encodeNetstring("domain broken.test"))
+	s.Require().NoError(err)
+	response, err := s.readNetstringResponse(client)
+	s.Require().NoError(err)
+	s.Contains(response, "TEMP")
+
+	s.False(mr.Exists(lookupCacheKeyPrefix+"domain:broken.test"),
+		"TEMP must not be cached")
+	mockService.AssertExpectations(s.T())
 }
 
 // TestSocketmapResponse_String tests the SocketmapResponse.String method

--- a/lookupcache.go
+++ b/lookupcache.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"go.uber.org/zap"
+)
+
+// lookupCacheKeyPrefix is the static Redis key prefix for cached lookup
+// responses. Each key combines the prefix, the socketmap name, and the
+// looked-up key (e.g. "userli:lookup:alias:user@example.com").
+const lookupCacheKeyPrefix = "userli:lookup:"
+
+// LookupCache caches successful socketmap lookup responses in Redis to reduce
+// load on the upstream Userli API. Only "OK" responses are cached so newly
+// created entries become visible without delay; "NOTFOUND", "TEMP" and "PERM"
+// responses are never written.
+//
+// All Redis errors fail open: Get returns a miss, Set is a no-op. Callers
+// always proceed to (or return from) the upstream handler unaffected.
+type LookupCache struct {
+	client *redis.Client
+	ttl    time.Duration
+	logger *zap.Logger
+}
+
+// NewLookupCache wraps an existing Redis client with the lookup-cache policy.
+// A non-positive ttl is invalid and indicates the caller should not construct
+// a cache at all (main.go passes nil instead).
+func NewLookupCache(client *redis.Client, ttl time.Duration, logger *zap.Logger) *LookupCache {
+	return &LookupCache{
+		client: client,
+		ttl:    ttl,
+		logger: logger,
+	}
+}
+
+// Get returns the cached response for (mapName, key) or (nil, false) on miss.
+// Redis errors are treated as misses so the caller falls through to the API.
+func (c *LookupCache) Get(ctx context.Context, mapName, key string) (*SocketmapResponse, bool) {
+	if c == nil {
+		return nil, false
+	}
+
+	val, err := c.client.Get(ctx, c.keyFor(mapName, key)).Result()
+	if errors.Is(err, redis.Nil) {
+		lookupCacheTotal.WithLabelValues(mapName, "miss").Inc()
+		return nil, false
+	}
+	if err != nil {
+		c.logger.Warn("Lookup cache get failed", zap.String("map", mapName), zap.Error(err))
+		lookupCacheTotal.WithLabelValues(mapName, "error").Inc()
+		return nil, false
+	}
+
+	lookupCacheTotal.WithLabelValues(mapName, "hit").Inc()
+	return parseCachedResponse(val), true
+}
+
+// Set stores the response in Redis when its status is OK. Other statuses are
+// intentionally ignored so the caching policy lives in one place.
+func (c *LookupCache) Set(ctx context.Context, mapName, key string, response *SocketmapResponse) {
+	if c == nil || response == nil || response.Status != "OK" {
+		return
+	}
+
+	if err := c.client.Set(ctx, c.keyFor(mapName, key), response.String(), c.ttl).Err(); err != nil {
+		c.logger.Warn("Lookup cache set failed", zap.String("map", mapName), zap.Error(err))
+		lookupCacheTotal.WithLabelValues(mapName, "error").Inc()
+	}
+}
+
+func (c *LookupCache) keyFor(mapName, key string) string {
+	return lookupCacheKeyPrefix + mapName + ":" + key
+}
+
+// parseCachedResponse splits the cached "<status>" or "<status> <data>" form
+// back into a SocketmapResponse. The cache only stores OK responses, but the
+// parser is forgiving in case a stale value with different shape is ever read.
+func parseCachedResponse(s string) *SocketmapResponse {
+	parts := strings.SplitN(s, " ", 2)
+	if len(parts) == 1 {
+		return &SocketmapResponse{Status: parts[0]}
+	}
+	return &SocketmapResponse{Status: parts[0], Data: parts[1]}
+}

--- a/lookupcache_test.go
+++ b/lookupcache_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"go.uber.org/zap"
+)
+
+func newTestLookupCache(t *testing.T) (*LookupCache, *miniredis.Miniredis) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	return NewLookupCache(client, 300*time.Second, zap.NewNop()), mr
+}
+
+func TestLookupCache_GetMiss(t *testing.T) {
+	cache, _ := newTestLookupCache(t)
+
+	resp, ok := cache.Get(context.Background(), "alias", "missing@example.com")
+	if ok {
+		t.Errorf("Expected miss, got hit with response %v", resp)
+	}
+	if resp != nil {
+		t.Errorf("Expected nil response on miss, got %v", resp)
+	}
+}
+
+func TestLookupCache_SetThenGetOK(t *testing.T) {
+	cache, _ := newTestLookupCache(t)
+	ctx := context.Background()
+
+	stored := &SocketmapResponse{Status: "OK", Data: "user1@example.com,user2@example.com"}
+	cache.Set(ctx, "alias", "alias@example.com", stored)
+
+	got, ok := cache.Get(ctx, "alias", "alias@example.com")
+	if !ok {
+		t.Fatal("Expected hit, got miss")
+	}
+	if got.Status != "OK" || got.Data != "user1@example.com,user2@example.com" {
+		t.Errorf("Cached response mismatch: got %v", got)
+	}
+}
+
+func TestLookupCache_SetThenGetOKBoolean(t *testing.T) {
+	// "OK 1" responses (from domain/mailbox handlers) must round-trip
+	// through the cache without losing the data field.
+	cache, _ := newTestLookupCache(t)
+	ctx := context.Background()
+
+	stored := &SocketmapResponse{Status: "OK", Data: "1"}
+	cache.Set(ctx, "domain", "example.com", stored)
+
+	got, ok := cache.Get(ctx, "domain", "example.com")
+	if !ok {
+		t.Fatal("Expected hit, got miss")
+	}
+	if got.Status != "OK" || got.Data != "1" {
+		t.Errorf("Cached response mismatch: got %v", got)
+	}
+}
+
+func TestLookupCache_SetSkipsNonOK(t *testing.T) {
+	cache, mr := newTestLookupCache(t)
+	ctx := context.Background()
+
+	for _, status := range []string{"NOTFOUND", "TEMP", "PERM"} {
+		key := "any@example.com"
+		cache.Set(ctx, "alias", key, &SocketmapResponse{Status: status, Data: "msg"})
+		if mr.Exists(lookupCacheKeyPrefix + "alias:" + key) {
+			t.Errorf("Cache must not store status %q", status)
+		}
+	}
+}
+
+func TestLookupCache_SetIgnoresNilResponse(t *testing.T) {
+	cache, mr := newTestLookupCache(t)
+	cache.Set(context.Background(), "alias", "x@example.com", nil)
+	if mr.Exists(lookupCacheKeyPrefix + "alias:x@example.com") {
+		t.Error("Cache must not store nil responses")
+	}
+}
+
+func TestLookupCache_TTLExpires(t *testing.T) {
+	cache, mr := newTestLookupCache(t)
+	ctx := context.Background()
+
+	cache.Set(ctx, "alias", "ttl@example.com", &SocketmapResponse{Status: "OK", Data: "x"})
+	if _, ok := cache.Get(ctx, "alias", "ttl@example.com"); !ok {
+		t.Fatal("Expected hit immediately after Set")
+	}
+
+	mr.FastForward(301 * time.Second)
+
+	if _, ok := cache.Get(ctx, "alias", "ttl@example.com"); ok {
+		t.Error("Expected miss after TTL expiry")
+	}
+}
+
+func TestLookupCache_KeysIsolatedByMapName(t *testing.T) {
+	cache, _ := newTestLookupCache(t)
+	ctx := context.Background()
+
+	cache.Set(ctx, "alias", "x", &SocketmapResponse{Status: "OK", Data: "alias-data"})
+	cache.Set(ctx, "domain", "x", &SocketmapResponse{Status: "OK", Data: "1"})
+
+	a, ok := cache.Get(ctx, "alias", "x")
+	if !ok || a.Data != "alias-data" {
+		t.Errorf("Expected alias data, got %v ok=%v", a, ok)
+	}
+	d, ok := cache.Get(ctx, "domain", "x")
+	if !ok || d.Data != "1" {
+		t.Errorf("Expected domain data, got %v ok=%v", d, ok)
+	}
+}
+
+// TestLookupCache_FailOpen verifies Redis errors at runtime do not propagate:
+// Get returns a miss and Set is a silent no-op, so handlers fall through to
+// the upstream API.
+func TestLookupCache_FailOpen(t *testing.T) {
+	cache, mr := newTestLookupCache(t)
+	mr.Close()
+
+	if _, ok := cache.Get(context.Background(), "alias", "x@example.com"); ok {
+		t.Error("Expected miss on Redis error")
+	}
+
+	cache.Set(context.Background(), "alias", "x@example.com", &SocketmapResponse{Status: "OK", Data: "v"})
+}
+
+// TestLookupCache_NilReceiver covers the "cache disabled" path — main.go passes
+// nil when LOOKUP_CACHE_TTL=0, so Get/Set must be safe on a nil receiver.
+func TestLookupCache_NilReceiver(t *testing.T) {
+	var cache *LookupCache
+
+	if _, ok := cache.Get(context.Background(), "alias", "x"); ok {
+		t.Error("Nil cache must return miss")
+	}
+
+	cache.Set(context.Background(), "alias", "x", &SocketmapResponse{Status: "OK", Data: "v"})
+}

--- a/main.go
+++ b/main.go
@@ -42,16 +42,24 @@ func main() {
 	}
 
 	userli := NewUserli(config.UserliToken, config.UserliBaseURL, WithDelimiter(config.PostfixRecipientDelimiter))
-	lookupServer := NewLookupServer(userli, logger.Named("lookup"))
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	rateLimiter, err := NewRateLimiter(ctx, config.RedisURL, logger.Named("ratelimit"))
+	redisClient, err := newRedisClient(ctx, config.RedisURL, logger.Named("redis"))
 	if err != nil {
-		logger.Fatal("Failed to initialize rate limiter", zap.Error(err))
+		logger.Fatal("Failed to initialize Redis client", zap.Error(err))
 	}
-	defer func() { _ = rateLimiter.Close() }()
+	defer func() { _ = redisClient.Close() }()
+
+	rateLimiter := NewRateLimiter(redisClient, logger.Named("ratelimit"))
+
+	var lookupCache *LookupCache
+	if config.LookupCacheTTL > 0 {
+		lookupCache = NewLookupCache(redisClient, config.LookupCacheTTL, logger.Named("lookupcache"))
+	}
+
+	lookupServer := NewLookupServer(userli, lookupCache, logger.Named("lookup"))
 	policyServer := NewPolicyServer(userli, rateLimiter, config.RateLimitMessage, logger.Named("policy"))
 
 	var wg sync.WaitGroup

--- a/prometheus.go
+++ b/prometheus.go
@@ -94,6 +94,11 @@ var (
 		Name: "userli_postfix_adapter_ratelimit_backend_errors_total",
 		Help: "Total number of rate-limit backend (Redis) errors, by operation",
 	}, []string{"operation"})
+
+	lookupCacheTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "userli_postfix_adapter_lookup_cache_total",
+		Help: "Total number of lookup cache events, by handler and result (hit, miss, error)",
+	}, []string{"handler", "result"})
 )
 
 // StartMetricsServer starts a new HTTP server for prometheus metrics and health checks.
@@ -117,6 +122,7 @@ func StartMetricsServer(ctx context.Context, listenAddr string, userliClient Use
 		quotaChecksTotal,
 		policyConnectionPoolFullTotal,
 		rateLimitBackendErrors,
+		lookupCacheTotal,
 	)
 
 	mux := http.NewServeMux()

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -11,6 +11,10 @@ import (
 	"go.uber.org/zap"
 )
 
+// Note: the Redis client is created once in main() (see newRedisClient in
+// redisclient.go) and shared with the lookup cache; RateLimiter does not own
+// its lifecycle.
+
 // rateLimitTTL is set slightly above 24h so a quiet sender's key naturally
 // evicts but no still-relevant timestamp is dropped early.
 const rateLimitTTL = 25 * time.Hour
@@ -63,30 +67,14 @@ type RateLimiter struct {
 	logger *zap.Logger
 }
 
-// NewRateLimiter parses the Redis URL, opens a client and pings the server.
-// A failed ping is logged as a warning but does not abort startup (fail-open).
-func NewRateLimiter(ctx context.Context, url string, logger *zap.Logger) (*RateLimiter, error) {
-	opts, err := redis.ParseURL(url)
-	if err != nil {
-		return nil, fmt.Errorf("parse redis url: %w", err)
-	}
-
-	client := redis.NewClient(opts)
-
-	pingCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
-	defer cancel()
-	if err := client.Ping(pingCtx).Err(); err != nil {
-		logger.Warn("Redis ping failed at startup, continuing fail-open",
-			zap.String("addr", opts.Addr), zap.Error(err))
-	} else {
-		logger.Info("Connected to Redis", zap.String("addr", opts.Addr))
-	}
-
+// NewRateLimiter wraps an existing Redis client with the sliding-window script.
+// Lifecycle of the client is owned by the caller.
+func NewRateLimiter(client *redis.Client, logger *zap.Logger) *RateLimiter {
 	return &RateLimiter{
 		client: client,
 		script: redis.NewScript(rateLimitScript),
 		logger: logger,
-	}, nil
+	}
 }
 
 // CheckAndIncrement runs the sliding-window check atomically in Redis.
@@ -154,11 +142,6 @@ func (rl *RateLimiter) GetCounts(ctx context.Context, sender string) (hourCount,
 	}
 
 	return int(hourCmd.Val()), int(dayCmd.Val())
-}
-
-// Close shuts down the Redis client.
-func (rl *RateLimiter) Close() error {
-	return rl.client.Close()
 }
 
 func keyFor(sender string) string {

--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -12,16 +12,13 @@ import (
 
 func TestNewRateLimiter_Success(t *testing.T) {
 	mr := miniredis.RunT(t)
-	url := "redis://" + mr.Addr()
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
 
-	rl, err := NewRateLimiter(context.Background(), url, zap.NewNop())
-	if err != nil {
-		t.Fatalf("NewRateLimiter returned error: %v", err)
-	}
+	rl := NewRateLimiter(client, zap.NewNop())
 	if rl == nil {
 		t.Fatal("NewRateLimiter returned nil limiter")
 	}
-	t.Cleanup(func() { _ = rl.Close() })
 
 	allowed, _, _ := rl.CheckAndIncrement(context.Background(), "smoke@example.org", &Quota{PerHour: 1, PerDay: 1})
 	if !allowed {
@@ -29,52 +26,11 @@ func TestNewRateLimiter_Success(t *testing.T) {
 	}
 }
 
-func TestNewRateLimiter_InvalidURL(t *testing.T) {
-	rl, err := NewRateLimiter(context.Background(), "://not-a-url", zap.NewNop())
-	if err == nil {
-		t.Fatal("Expected error for malformed URL")
-	}
-	if rl != nil {
-		t.Errorf("Expected nil limiter on parse error, got %v", rl)
-	}
-}
-
-func TestNewRateLimiter_PingFailureFailsOpen(t *testing.T) {
-	// Point at an address that nothing is listening on so the PING fails fast.
-	// Constructor must still return a usable limiter (fail-open at startup).
-	// Tight dial timeout keeps the test fast despite go-redis pool retries.
-	url := "redis://127.0.0.1:1?dial_timeout=100ms"
-
-	rl, err := NewRateLimiter(context.Background(), url, zap.NewNop())
-	if err != nil {
-		t.Fatalf("Expected no error on PING failure, got %v", err)
-	}
-	if rl == nil {
-		t.Fatal("Expected non-nil limiter even when PING fails")
-	}
-	t.Cleanup(func() { _ = rl.Close() })
-
-	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
-	defer cancel()
-
-	allowed, hourCount, dayCount := rl.CheckAndIncrement(ctx, "ping@example.org", &Quota{PerHour: 1, PerDay: 1})
-	if !allowed {
-		t.Error("Expected fail-open when Redis is unreachable")
-	}
-	if hourCount != 0 || dayCount != 0 {
-		t.Errorf("Expected zero counts on fail-open, got hour=%d, day=%d", hourCount, dayCount)
-	}
-}
-
 func newTestRateLimiter(t *testing.T) (*RateLimiter, *miniredis.Miniredis) {
 	t.Helper()
 	mr := miniredis.RunT(t)
 	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
-	rl := &RateLimiter{
-		client: client,
-		script: redis.NewScript(rateLimitScript),
-		logger: zap.NewNop(),
-	}
+	rl := NewRateLimiter(client, zap.NewNop())
 	t.Cleanup(func() { _ = client.Close() })
 	return rl, mr
 }

--- a/redisclient.go
+++ b/redisclient.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"go.uber.org/zap"
+)
+
+// newRedisClient parses the Redis URL, opens a client, and pings the server.
+// A failed ping is logged as a warning but does not abort startup (fail-open).
+func newRedisClient(ctx context.Context, url string, logger *zap.Logger) (*redis.Client, error) {
+	opts, err := redis.ParseURL(url)
+	if err != nil {
+		return nil, fmt.Errorf("parse redis url: %w", err)
+	}
+
+	client := redis.NewClient(opts)
+
+	pingCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	if err := client.Ping(pingCtx).Err(); err != nil {
+		logger.Warn("Redis ping failed at startup, continuing fail-open",
+			zap.String("addr", opts.Addr), zap.Error(err))
+	} else {
+		logger.Info("Connected to Redis", zap.String("addr", opts.Addr))
+	}
+
+	return client, nil
+}

--- a/redisclient_test.go
+++ b/redisclient_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"go.uber.org/zap"
+)
+
+func TestNewRedisClient_Success(t *testing.T) {
+	mr := miniredis.RunT(t)
+
+	client, err := newRedisClient(context.Background(), "redis://"+mr.Addr(), zap.NewNop())
+	if err != nil {
+		t.Fatalf("newRedisClient returned error: %v", err)
+	}
+	if client == nil {
+		t.Fatal("newRedisClient returned nil client")
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	if err := client.Ping(context.Background()).Err(); err != nil {
+		t.Errorf("Expected ping to succeed, got %v", err)
+	}
+}
+
+func TestNewRedisClient_InvalidURL(t *testing.T) {
+	client, err := newRedisClient(context.Background(), "://not-a-url", zap.NewNop())
+	if err == nil {
+		t.Fatal("Expected error for malformed URL")
+	}
+	if client != nil {
+		t.Errorf("Expected nil client on parse error, got %v", client)
+	}
+}
+
+// TestNewRedisClient_PingFailureFailsOpen verifies that a Redis server that
+// is unreachable at startup does not abort the constructor — the client is
+// returned anyway so the rest of the app can boot and other components can
+// fail open at runtime.
+func TestNewRedisClient_PingFailureFailsOpen(t *testing.T) {
+	// Tight dial timeout keeps the test fast despite go-redis pool retries.
+	client, err := newRedisClient(context.Background(),
+		"redis://127.0.0.1:1?dial_timeout=100ms", zap.NewNop())
+	if err != nil {
+		t.Fatalf("Expected no error on PING failure, got %v", err)
+	}
+	if client == nil {
+		t.Fatal("Expected non-nil client even when PING fails")
+	}
+	t.Cleanup(func() { _ = client.Close() })
+}


### PR DESCRIPTION
## Summary

Caches successful (`OK`) socketmap lookup responses in Redis to reduce pressure on the Userli API and cut lookup latency. Each Postfix delivery re-asks the same `alias` / `domain` / `mailbox` / `senders` lookups multiple times; today every one of those reaches the upstream API, even when the answer just came back milliseconds ago.

## Behavior

- **Caches `OK` only.** `NOTFOUND` is intentionally not cached so newly-created users/aliases become visible without waiting for TTL expiry. `TEMP` / `PERM` are transient or protocol errors and must not be cached.
- **TTL** is configurable via `LOOKUP_CACHE_TTL` (Go duration). Defaults to `300s`. Setting it to `0` disables the cache entirely; in that case no Redis calls are made for lookups.
- **Fail-open.** Any Redis error on `GET` is treated as a miss; on `SET` it is a silent no-op. Errors are logged and tracked in `userli_postfix_adapter_lookup_cache_total{result="error"}`. Lookups always fall through to the upstream API.
- **Shared Redis client.** The client is now created once in `main` (`newRedisClient` helper extracted from the rate limiter) and shared with both the rate limiter and the lookup cache. Single connection pool, single `Close`.
- **Cache key format:** `userli:lookup:<mapname>:<key>` — same `userli:` namespace style as `userli:ratelimit:sender:`.

## Observability

New Prometheus counter:

```
userli_postfix_adapter_lookup_cache_total{handler, result}   # result: hit | miss | error
```

## Configuration

New env var, documented in `README.md` and `.env.example`:

```
LOOKUP_CACHE_TTL=300s   # default; "0" disables the cache
```

---
<sub>The changes and the PR were generated by Claude.</sub>