### PR TITLE
:bug: Validate SASL UNIX socket creation and clarify start log

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ smtpd_sasl_path = private/auth
 smtpd_sasl_auth_enable = yes
 ```
 
+When the adapter runs in a container or under a chroot, the socket path must be reachable by Postfix — typically a shared volume mounted into both, or a path inside Postfix's chroot directory (`/var/spool/postfix/`). A path like `/tmp/...` inside the adapter container is not visible to Postfix on the host.
+
 ## Docker
 
 You can run the adapter using Docker.

--- a/sasl_test.go
+++ b/sasl_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -408,4 +410,58 @@ func TestSASL_CUIDIncrementsPerConnection(t *testing.T) {
 	assert.NotEmpty(t, cuid1)
 	assert.NotEmpty(t, cuid2)
 	assert.NotEqual(t, cuid1, cuid2, "CUID should increment per connection")
+}
+
+func TestSASL_UnixSocket_Listener(t *testing.T) {
+	logger = zap.NewNop()
+	mockService := &MockUserliService{}
+	mockService.On("Authenticate", mock.Anything, "user@example.org", "secret").Return(true, "success", nil)
+
+	addr := filepath.Join(t.TempDir(), "sasl.sock")
+
+	server := NewSASLServer(mockService, zap.NewNop())
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go StartSASLServer(ctx, &wg, addr, server)
+
+	// Poll for the socket to appear (server starts asynchronously).
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if info, err := os.Stat(addr); err == nil {
+			require.NotZero(t, info.Mode()&os.ModeSocket,
+				"path exists but is not a UNIX socket: mode=%s", info.Mode())
+			break
+		}
+		if time.Now().After(deadline) {
+			cancel()
+			wg.Wait()
+			t.Fatalf("UNIX socket %q not created within timeout", addr)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Dial over UNIX and run a full PLAIN AUTH exchange to prove the listener works.
+	conn, err := net.DialTimeout("unix", addr, 2*time.Second)
+	require.NoError(t, err)
+	h := &saslTestHelper{
+		t:      t,
+		conn:   conn,
+		reader: bufio.NewReader(conn),
+		writer: bufio.NewWriter(conn),
+	}
+	h.doHandshake()
+	resp := h.sendPlainAuth("1", "user@example.org", "secret")
+	assert.Equal(t, "OK\t1\tuser=user@example.org", resp)
+	h.close()
+
+	// Cancel and ensure the socket is cleaned up.
+	cancel()
+	wg.Wait()
+	_, err = os.Stat(addr)
+	assert.True(t, os.IsNotExist(err),
+		"socket file should be removed on shutdown, got err=%v", err)
+
+	mockService.AssertExpectations(t)
 }

--- a/tcpserver.go
+++ b/tcpserver.go
@@ -79,25 +79,6 @@ func StartTCPServer(ctx context.Context, wg *sync.WaitGroup, config TCPServerCon
 			listener.Close()
 			return
 		}
-
-		// Confirm the socket file is actually present at the expected path.
-		// If something raced to delete it (or net.Listen produced a file at
-		// an unexpected location), fail loudly instead of silently logging
-		// "Server started" while Postfix can't connect.
-		info, statErr := os.Stat(config.Addr)
-		if statErr != nil {
-			config.Logger.Error("UNIX socket file missing after listen",
-				zap.String("addr", config.Addr), zap.Error(statErr))
-			listener.Close()
-			return
-		}
-		if info.Mode()&os.ModeSocket == 0 {
-			config.Logger.Error("Path exists but is not a socket",
-				zap.String("addr", config.Addr),
-				zap.String("mode", info.Mode().String()))
-			listener.Close()
-			return
-		}
 	} else {
 		lc := net.ListenConfig{
 			KeepAlive: KeepAliveTimeout,

--- a/tcpserver.go
+++ b/tcpserver.go
@@ -59,7 +59,9 @@ func StartTCPServer(ctx context.Context, wg *sync.WaitGroup, config TCPServerCon
 	var listener net.Listener
 	var err error
 
+	network := "tcp"
 	if isUnixSocket(config.Addr) {
+		network = "unix"
 		// Remove stale socket file if it exists
 		_ = os.Remove(config.Addr)
 
@@ -74,6 +76,25 @@ func StartTCPServer(ctx context.Context, wg *sync.WaitGroup, config TCPServerCon
 		if chmodErr := os.Chmod(config.Addr, 0666); chmodErr != nil {
 			config.Logger.Error("Failed to set socket permissions",
 				zap.String("addr", config.Addr), zap.Error(chmodErr))
+			listener.Close()
+			return
+		}
+
+		// Confirm the socket file is actually present at the expected path.
+		// If something raced to delete it (or net.Listen produced a file at
+		// an unexpected location), fail loudly instead of silently logging
+		// "Server started" while Postfix can't connect.
+		info, statErr := os.Stat(config.Addr)
+		if statErr != nil {
+			config.Logger.Error("UNIX socket file missing after listen",
+				zap.String("addr", config.Addr), zap.Error(statErr))
+			listener.Close()
+			return
+		}
+		if info.Mode()&os.ModeSocket == 0 {
+			config.Logger.Error("Path exists but is not a socket",
+				zap.String("addr", config.Addr),
+				zap.String("mode", info.Mode().String()))
 			listener.Close()
 			return
 		}
@@ -105,6 +126,7 @@ func StartTCPServer(ctx context.Context, wg *sync.WaitGroup, config TCPServerCon
 	}()
 
 	config.Logger.Info("Server started",
+		zap.String("network", network),
 		zap.String("addr", config.Addr))
 
 	for {


### PR DESCRIPTION
## Summary

Reactive change to a bug report: with `SASL_LISTEN_ADDR=/tmp/userli-postfix-adapter-sasl`, the startup log reported `"Server started"` while no socket file was visible at that path.

The most likely real-world cause is a filesystem-namespace mismatch (the adapter runs in a container/chroot and the socket lives on a path Postfix can't see), but `tcpserver.go` was also too quiet to tell that case apart from a true bind failure. This PR makes the failure modes diagnosable and pins the UNIX-socket contract with a test.

## Goal

Turn a confusing, silent-looking startup into something that either works visibly or fails loudly with the path and reason.

## Changes

- `tcpserver.go` — after `net.Listen("unix", …)` + `chmod 0666`, `os.Stat` the path and verify `os.ModeSocket`. If the file is missing or not a socket, log the error, close the listener, and bail out instead of advertising the server as started. Also add a `network` field (`tcp`/`unix`) to the `"Server started"` log.
- `sasl_test.go` — new `TestSASL_UnixSocket_Listener` that starts the SASL server on a `t.TempDir()/sasl.sock` path, polls for the file, asserts `os.ModeSocket`, dials over `unix`, runs the full Dovecot handshake plus a PLAIN AUTH exchange, and confirms the socket is removed on `cancel()`.
- `README.md` — one-sentence note that the SASL socket path must be reachable by Postfix in containerized/chrooted setups (a `/tmp/...` path inside the adapter container is not visible to Postfix on the host).

---
<sub>The changes and the PR were generated by Claude.</sub>