### PR TITLE
:bug: Fix Dovecot SASL handshake order so Postfix accepts auth-client

### DIFF
--- a/sasl.go
+++ b/sasl.go
@@ -104,13 +104,15 @@ func (s *SASLServer) sendHandshake(writer *bufio.Writer, cuid uint64) error {
 		return fmt.Errorf("failed to generate cookie: %w", err)
 	}
 
+	// MECH lines must precede SPID: Postfix uses SPID-before-MECH as the
+	// signal that it has connected to an auth-master socket and aborts.
 	lines := []string{
 		"VERSION\t1\t2",
+		"MECH\tPLAIN\tplaintext",
+		"MECH\tLOGIN\tplaintext",
 		fmt.Sprintf("SPID\t%d", os.Getpid()),
 		fmt.Sprintf("CUID\t%d", cuid),
 		fmt.Sprintf("COOKIE\t%032x", cookie),
-		"MECH\tPLAIN\tplaintext",
-		"MECH\tLOGIN\tplaintext",
 		"DONE",
 	}
 

--- a/sasl_test.go
+++ b/sasl_test.go
@@ -162,19 +162,19 @@ func TestSASL_Handshake(t *testing.T) {
 
 	lines := h.readServerHandshake()
 
-	// Verify handshake lines
+	// Verify handshake lines. MECH must come before SPID so Postfix
+	// recognizes this as an auth-client (not auth-master) socket.
 	assert.True(t, strings.HasPrefix(lines[0], "VERSION\t1\t2"), "first line should be VERSION")
-	assert.True(t, strings.HasPrefix(lines[1], "SPID\t"), "second line should be SPID")
-	assert.True(t, strings.HasPrefix(lines[2], "CUID\t"), "third line should be CUID")
-	assert.True(t, strings.HasPrefix(lines[3], "COOKIE\t"), "fourth line should be COOKIE")
+	assert.Equal(t, "MECH\tPLAIN\tplaintext", lines[1])
+	assert.Equal(t, "MECH\tLOGIN\tplaintext", lines[2])
+	assert.True(t, strings.HasPrefix(lines[3], "SPID\t"), "fourth line should be SPID")
+	assert.True(t, strings.HasPrefix(lines[4], "CUID\t"), "fifth line should be CUID")
+	assert.True(t, strings.HasPrefix(lines[5], "COOKIE\t"), "sixth line should be COOKIE")
 
 	// Check COOKIE is 32 hex chars
-	cookie := strings.TrimPrefix(lines[3], "COOKIE\t")
+	cookie := strings.TrimPrefix(lines[5], "COOKIE\t")
 	assert.Len(t, cookie, 32)
 
-	// Verify mechanisms
-	assert.Equal(t, "MECH\tPLAIN\tplaintext", lines[4])
-	assert.Equal(t, "MECH\tLOGIN\tplaintext", lines[5])
 	assert.Equal(t, "DONE", lines[6])
 
 	// Send client handshake


### PR DESCRIPTION
## Summary

When testing the new Dovecot SASL auth server (added in #76) against a Postfix submission service, Postfix immediately rejects the connection:

```
xsasl_dovecot_server_connect: auth reply: VERSION?1?2
xsasl_dovecot_server_connect: auth reply: SPID?1028078
warning: SASL: Connected to wrong auth socket (auth-master instead of auth-client)
fatal: no SASL authentication mechanisms
```

## Root cause

Postfix' `xsasl_dovecot_server.c` decides whether it talked to `auth-client` or `auth-master` *while* reading the handshake: as soon as it sees a `SPID` line without any preceding `MECH`, it concludes it is connected to an auth-master socket and aborts — it never reads the `MECH` lines that follow.

Our `sendHandshake` emitted `SPID`/`CUID`/`COOKIE` before the `MECH` lines, which is exactly the auth-master signature. Dovecot's own auth-client server (`auth_client_handshake_send` in `src/auth/auth-client-connection.c`) sends `MECH` lines directly after `VERSION`, before `SPID`/`CUID`/`COOKIE`.

## Fix

- Reorder the handshake in `sendHandshake` so `MECH` lines follow `VERSION` and precede `SPID`/`CUID`/`COOKIE`.
- Update `TestSASL_Handshake`, which had pinned the wrong order and therefore did not catch this regression.

---
<sub>The changes and the PR were generated by Claude.</sub>