### PR TITLE
:bug: Return permanent failure on invalid SASL credentials

### DIFF
--- a/sasl.go
+++ b/sasl.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -60,13 +61,14 @@ func (s *SASLServer) HandleConnection(ctx context.Context, conn net.Conn) {
 	cuid := s.connID.Add(1)
 
 	// Send server handshake
+	_ = conn.SetWriteDeadline(time.Now().Add(WriteTimeout))
 	if err := s.sendHandshake(writer, cuid); err != nil {
 		s.logger.Error("failed to send handshake", zap.Error(err))
 		return
 	}
 
 	// Read client handshake
-	if err := s.readClientHandshake(reader); err != nil {
+	if err := s.readClientHandshake(conn, reader); err != nil {
 		s.logger.Error("failed to read client handshake", zap.Error(err))
 		return
 	}
@@ -77,8 +79,15 @@ func (s *SASLServer) HandleConnection(ctx context.Context, conn net.Conn) {
 			return
 		}
 
+		_ = conn.SetReadDeadline(time.Now().Add(ReadTimeout))
+
 		line, err := reader.ReadString('\n')
 		if err != nil {
+			var netErr net.Error
+			if errors.As(err, &netErr) && netErr.Timeout() {
+				return
+			}
+			s.logger.Debug("failed to read AUTH request", zap.Error(err))
 			return
 		}
 		line = strings.TrimRight(line, "\r\n")
@@ -90,7 +99,7 @@ func (s *SASLServer) HandleConnection(ctx context.Context, conn net.Conn) {
 
 		switch parts[0] {
 		case "AUTH":
-			s.handleAuth(ctx, reader, writer, parts)
+			s.handleAuth(ctx, conn, reader, writer, parts)
 		default:
 			s.logger.Debug("ignoring unknown command", zap.String("command", parts[0]))
 		}
@@ -126,11 +135,12 @@ func (s *SASLServer) sendHandshake(writer *bufio.Writer, cuid uint64) error {
 }
 
 // readClientHandshake reads and validates the client (Postfix) handshake.
-func (s *SASLServer) readClientHandshake(reader *bufio.Reader) error {
+func (s *SASLServer) readClientHandshake(conn net.Conn, reader *bufio.Reader) error {
 	gotVersion := false
 	gotCPID := false
 
 	for {
+		_ = conn.SetReadDeadline(time.Now().Add(ReadTimeout))
 		line, err := reader.ReadString('\n')
 		if err != nil {
 			return fmt.Errorf("failed to read client handshake: %w", err)
@@ -163,10 +173,10 @@ func (s *SASLServer) readClientHandshake(reader *bufio.Reader) error {
 }
 
 // handleAuth processes an AUTH request and sends OK or FAIL.
-func (s *SASLServer) handleAuth(ctx context.Context, reader *bufio.Reader, writer *bufio.Writer, parts []string) {
+func (s *SASLServer) handleAuth(ctx context.Context, conn net.Conn, reader *bufio.Reader, writer *bufio.Writer, parts []string) {
 	// AUTH\t<id>\t<mechanism>\t[params...]
 	if len(parts) < 3 {
-		s.writeResponse(writer, "FAIL\t0\treason=Invalid AUTH request")
+		s.writeResponse(conn, writer, "FAIL\t0\treason=Invalid AUTH request")
 		return
 	}
 
@@ -182,21 +192,21 @@ func (s *SASLServer) handleAuth(ctx context.Context, reader *bufio.Reader, write
 	case "PLAIN":
 		email, password, err = s.parsePlainAuth(parts)
 	case "LOGIN":
-		email, password, err = s.handleLoginAuth(id, reader, writer)
+		email, password, err = s.handleLoginAuth(id, conn, reader, writer)
 	default:
 		s.recordAuthResult(mechanism, "error", startTime)
-		s.writeResponse(writer, fmt.Sprintf("FAIL\t%s\treason=Unsupported mechanism", id))
+		s.writeResponse(conn, writer, fmt.Sprintf("FAIL\t%s\treason=Unsupported mechanism", id))
 		return
 	}
 
 	if err != nil {
 		s.logger.Info("auth parsing failed", zap.String("mechanism", mechanism), zap.Error(err))
 		s.recordAuthResult(mechanism, "error", startTime)
-		s.writeResponse(writer, fmt.Sprintf("FAIL\t%s\treason=%s", id, err.Error()))
+		s.writeResponse(conn, writer, fmt.Sprintf("FAIL\t%s\treason=%s", id, sanitizeField(err.Error())))
 		return
 	}
 
-	s.authenticateAndRespond(ctx, writer, id, mechanism, email, password, startTime)
+	s.authenticateAndRespond(ctx, conn, writer, id, mechanism, email, password, startTime)
 }
 
 // parsePlainAuth extracts email and password from a PLAIN AUTH request.
@@ -245,12 +255,13 @@ func (s *SASLServer) parsePlainAuth(parts []string) (string, string, error) {
 //	C: CONT\t<id>\t<base64(username)>
 //	S: CONT\t<id>\t<base64("Password:")>
 //	C: CONT\t<id>\t<base64(password)>
-func (s *SASLServer) handleLoginAuth(id string, reader *bufio.Reader, writer *bufio.Writer) (string, string, error) {
+func (s *SASLServer) handleLoginAuth(id string, conn net.Conn, reader *bufio.Reader, writer *bufio.Writer) (string, string, error) {
 	// Send Username challenge
 	usernameChallenge := base64.StdEncoding.EncodeToString([]byte("Username:"))
-	s.writeResponse(writer, fmt.Sprintf("CONT\t%s\t%s", id, usernameChallenge))
+	s.writeResponse(conn, writer, fmt.Sprintf("CONT\t%s\t%s", id, usernameChallenge))
 
 	// Read username response
+	_ = conn.SetReadDeadline(time.Now().Add(ReadTimeout))
 	line, err := reader.ReadString('\n')
 	if err != nil {
 		return "", "", fmt.Errorf("failed to read LOGIN username: %w", err)
@@ -270,9 +281,10 @@ func (s *SASLServer) handleLoginAuth(id string, reader *bufio.Reader, writer *bu
 
 	// Send Password challenge
 	passwordChallenge := base64.StdEncoding.EncodeToString([]byte("Password:"))
-	s.writeResponse(writer, fmt.Sprintf("CONT\t%s\t%s", id, passwordChallenge))
+	s.writeResponse(conn, writer, fmt.Sprintf("CONT\t%s\t%s", id, passwordChallenge))
 
 	// Read password response
+	_ = conn.SetReadDeadline(time.Now().Add(ReadTimeout))
 	line, err = reader.ReadString('\n')
 	if err != nil {
 		return "", "", fmt.Errorf("failed to read LOGIN password: %w", err)
@@ -298,21 +310,21 @@ func (s *SASLServer) handleLoginAuth(id string, reader *bufio.Reader, writer *bu
 }
 
 // authenticateAndRespond calls the Userli API and writes the auth result.
-func (s *SASLServer) authenticateAndRespond(ctx context.Context, writer *bufio.Writer, id, mechanism, email, password string, startTime time.Time) {
+func (s *SASLServer) authenticateAndRespond(ctx context.Context, conn net.Conn, writer *bufio.Writer, id, mechanism, email, password string, startTime time.Time) {
 	ok, message, err := s.client.Authenticate(ctx, email, password)
 	if err != nil {
 		// Fail-closed: API errors reject authentication
 		s.logger.Error("authentication API error",
 			zap.String("email", email), zap.Error(err))
 		s.recordAuthResult(mechanism, "error", startTime)
-		s.writeResponse(writer, fmt.Sprintf("FAIL\t%s\tuser=%s\treason=Internal error", id, email))
+		s.writeResponse(conn, writer, fmt.Sprintf("FAIL\t%s\tuser=%s\treason=Internal error", id, sanitizeField(email)))
 		return
 	}
 
 	if ok {
 		s.logger.Info("authentication successful", zap.String("email", email))
 		s.recordAuthResult(mechanism, "success", startTime)
-		s.writeResponse(writer, fmt.Sprintf("OK\t%s\tuser=%s", id, email))
+		s.writeResponse(conn, writer, fmt.Sprintf("OK\t%s\tuser=%s", id, sanitizeField(email)))
 	} else {
 		reason := message
 		if reason == "" {
@@ -320,18 +332,33 @@ func (s *SASLServer) authenticateAndRespond(ctx context.Context, writer *bufio.W
 		}
 		s.logger.Info("authentication failed", zap.String("email", email), zap.String("reason", reason))
 		s.recordAuthResult(mechanism, "invalid_credentials", startTime)
-		s.writeResponse(writer, fmt.Sprintf("FAIL\t%s\tuser=%s\treason=%s", id, email, reason))
+		s.writeResponse(conn, writer, fmt.Sprintf("FAIL\t%s\tuser=%s\treason=%s", id, sanitizeField(email), sanitizeField(reason)))
 	}
 }
 
 // writeResponse writes a line to the writer and flushes.
-func (s *SASLServer) writeResponse(writer *bufio.Writer, line string) {
+func (s *SASLServer) writeResponse(conn net.Conn, writer *bufio.Writer, line string) {
+	_ = conn.SetWriteDeadline(time.Now().Add(WriteTimeout))
 	if _, err := writer.WriteString(line + "\n"); err != nil {
 		s.logger.Error("failed to write response", zap.Error(err))
 	}
 	if err := writer.Flush(); err != nil {
 		s.logger.Error("failed to flush response", zap.Error(err))
 	}
+}
+
+// sanitizeField removes characters that would break the Dovecot auth
+// protocol's tab/newline framing. Postfix treats reason/user as opaque
+// text up to the next field separator.
+func sanitizeField(s string) string {
+	return strings.Map(func(r rune) rune {
+		switch r {
+		case '\t', '\n', '\r':
+			return ' '
+		default:
+			return r
+		}
+	}, s)
 }
 
 // recordAuthResult records metrics for an authentication attempt.

--- a/sasl_test.go
+++ b/sasl_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"io"
 	"net"
 	"strings"
 	"sync"
@@ -408,4 +409,98 @@ func TestSASL_CUIDIncrementsPerConnection(t *testing.T) {
 	assert.NotEmpty(t, cuid1)
 	assert.NotEmpty(t, cuid2)
 	assert.NotEqual(t, cuid1, cuid2, "CUID should increment per connection")
+}
+
+// assertNoTempParameter asserts that a FAIL response does not contain the
+// `temp` flag or `temp=` parameter — Postfix maps either to 454 (retryable),
+// while permanent auth failures must produce 535.
+func assertNoTempParameter(t *testing.T, resp string) {
+	t.Helper()
+	require.True(t, strings.HasPrefix(resp, "FAIL\t"), "expected FAIL response, got: %q", resp)
+	fields := strings.Split(resp, "\t")
+	for _, f := range fields[2:] {
+		assert.NotEqual(t, "temp", f, "FAIL must not contain bare temp parameter")
+		assert.False(t, strings.HasPrefix(f, "temp="), "FAIL must not contain temp= parameter, got field: %q", f)
+	}
+}
+
+func TestSASL_FailResponse_NoTempParameter(t *testing.T) {
+	logger = zap.NewNop()
+	mockService := &MockUserliService{}
+	mockService.On("Authenticate", mock.Anything, "user@example.org", "wrong").
+		Return(false, "authentication failed", nil)
+	addr, _ := startSASLTestServer(t, mockService)
+
+	h := newSASLTestHelper(t, addr)
+	defer h.close()
+	h.doHandshake()
+
+	resp := h.sendPlainAuth("1", "user@example.org", "wrong")
+	assertNoTempParameter(t, resp)
+	mockService.AssertExpectations(t)
+}
+
+func TestSASL_FailResponse_APIError_NoTempParameter(t *testing.T) {
+	logger = zap.NewNop()
+	mockService := &MockUserliService{}
+	mockService.On("Authenticate", mock.Anything, "user@example.org", "secret").
+		Return(false, "", fmt.Errorf("connection refused"))
+	addr, _ := startSASLTestServer(t, mockService)
+
+	h := newSASLTestHelper(t, addr)
+	defer h.close()
+	h.doHandshake()
+
+	resp := h.sendPlainAuth("1", "user@example.org", "secret")
+	assertNoTempParameter(t, resp)
+	mockService.AssertExpectations(t)
+}
+
+func TestSASL_FailResponse_SanitizesReason(t *testing.T) {
+	logger = zap.NewNop()
+	mockService := &MockUserliService{}
+	mockService.On("Authenticate", mock.Anything, "user@example.org", "wrong").
+		Return(false, "bad\tcreds\nfor user", nil)
+	addr, _ := startSASLTestServer(t, mockService)
+
+	h := newSASLTestHelper(t, addr)
+	defer h.close()
+	h.doHandshake()
+
+	resp := h.sendPlainAuth("1", "user@example.org", "wrong")
+	require.True(t, strings.HasPrefix(resp, "FAIL\t1\t"))
+
+	var reasonField string
+	for f := range strings.SplitSeq(resp, "\t") {
+		if rest, ok := strings.CutPrefix(f, "reason="); ok {
+			reasonField = rest
+		}
+	}
+	require.NotEmpty(t, reasonField)
+	assert.NotContains(t, reasonField, "\t")
+	assert.NotContains(t, reasonField, "\n")
+	assert.NotContains(t, reasonField, "\r")
+	assert.Equal(t, "bad creds for user", reasonField)
+	mockService.AssertExpectations(t)
+}
+
+// TestSASL_IdleConnection_ClosesCleanly verifies that the server cleanly
+// closes idle connections via the per-iteration ReadDeadline rather than
+// holding onto them under the global ConnectionTimeout (which previously
+// caused `reader.ReadString` to time out mid-AUTH after 60s, closing the
+// connection without sending a FAIL — Postfix then mapped that EOF to
+// 454 "Connection lost to authentication server" instead of 535).
+func TestSASL_IdleConnection_ClosesCleanly(t *testing.T) {
+	logger = zap.NewNop()
+	mockService := &MockUserliService{}
+	addr, _ := startSASLTestServer(t, mockService)
+
+	h := newSASLTestHelper(t, addr)
+	defer h.close()
+	h.doHandshake()
+
+	// Allow more than ReadTimeout (10s) of idle so the server closes us.
+	h.conn.SetReadDeadline(time.Now().Add(ReadTimeout + 5*time.Second))
+	_, err := h.reader.ReadString('\n')
+	assert.ErrorIs(t, err, io.EOF, "server must close idle connections cleanly")
 }


### PR DESCRIPTION
## Summary

Failed SASL logins through the adapter were returning Postfix's temporary `454 4.7.0 Temporary authentication failure: Connection lost to authentication server` instead of the permanent `535 5.7.8 Error: authentication failed`. The temporary status causes SMTP clients to retry with the same wrong credentials.

## Root cause

The AUTH loop in `sasl.go` relied solely on the global 60-second `ConnectionTimeout` set once in `tcpserver.go`. When that wall-clock deadline expired, the next `reader.ReadString` returned a timeout error and the handler returned silently, closing the connection without sending a FAIL response. Postfix read EOF and mapped that to `XSASL_AUTH_TEMP` → 454.

A secondary protocol-corruption risk: the `reason` field from the Userli API was interpolated unsanitized into the tab-delimited FAIL frame, so any `\t` or `\n` in the API message would have broken Postfix's parser the same way.

## Fix

- Adopt the per-operation deadline pattern from `policy.go` and `lookup.go`: refresh `SetReadDeadline(ReadTimeout)` before each read in the AUTH loop, the client handshake, and the LOGIN `CONT` roundtrips; set `SetWriteDeadline(WriteTimeout)` centrally in `writeResponse`; silently return on `netErr.Timeout()` for idle reads instead of leaking a stale FAIL.
- Add a `sanitizeField` helper that replaces `\t`, `\r`, `\n` with spaces, and apply it to `email` and `reason` before they go into the FAIL/OK frame.

---
<sub>The changes and the PR were generated by Claude.</sub>